### PR TITLE
Pass User-Agent header in URL validation HEAD request

### DIFF
--- a/src/controllers/submitUrlController.js
+++ b/src/controllers/submitUrlController.js
@@ -44,18 +44,19 @@ class SubmitUrlController extends UploadController {
       { type: 'format', fn: () => SubmitUrlController.urlIsValid(url) },
       { type: 'length', fn: () => SubmitUrlController.urlIsNotTooLong(url) }
     ]
-
-    const headRequest = await SubmitUrlController.headRequest(url)
-
-    if (headRequest) {
-      validators.push(
-        { type: 'exists', fn: () => SubmitUrlController.urlExists(headRequest) },
-        { type: 'filetype', fn: () => SubmitUrlController.validateAcceptedFileType(headRequest) },
-        { type: 'size', fn: () => SubmitUrlController.urlResponseIsNotTooLarge(headRequest) }
-      )
+    const preCheckFailure = validators.find(validator => !validator.fn())
+    if (preCheckFailure) {
+      return preCheckFailure.type
     }
 
-    return validators.find(validator => !validator.fn())?.type
+    const postValidators = (resp) => ([
+      { type: 'exists', fn: () => SubmitUrlController.urlExists(resp) },
+      { type: 'filetype', fn: () => SubmitUrlController.validateAcceptedFileType(resp) },
+      { type: 'size', fn: () => SubmitUrlController.urlResponseIsNotTooLarge(resp) }
+    ])
+    const headResponse = await SubmitUrlController.headRequest(url)
+
+    return postValidators(headResponse).find(validator => !validator.fn())?.type
   }
 
   static urlIsDefined (url) {

--- a/src/controllers/submitUrlController.js
+++ b/src/controllers/submitUrlController.js
@@ -45,7 +45,7 @@ class SubmitUrlController extends UploadController {
       { type: 'length', fn: () => SubmitUrlController.urlIsNotTooLong(url) }
     ]
 
-    const headRequest = await SubmitUrlController.getHeadRequest(url)
+    const headRequest = await SubmitUrlController.headRequest(url)
 
     if (headRequest) {
       validators.push(
@@ -76,10 +76,11 @@ class SubmitUrlController extends UploadController {
     return url.length <= 2048
   }
 
-  static async getHeadRequest (url) {
+  static async headRequest (url) {
     try {
-      return await axios.head(url)
+      return await axios.head(url, { headers: { 'User-Agent': 'check service' } })
     } catch (err) {
+      logger.info({ message: `SubmitUrlController.headRequest(): err.code=${err.code}`, type: types.External, responseStatus: err?.response?.status, url })
       if (err.code && ['ENOTFOUND', 'ECONNREFUSED'].includes(err.code)) {
         return null
       }

--- a/test/unit/submitUrlController.test.js
+++ b/test/unit/submitUrlController.test.js
@@ -103,16 +103,10 @@ describe('SubmitUrlController', async () => {
   })
 
   describe('getHeadRequest', () => {
-    it('should call axios.head with the correct URL', async () => {
-      mocks.headMock.mockImplementation(() => ({ headers: { 'content-length': '1' } }))
-      await SubmitUrlController.getHeadRequest('http://example.com')
-      expect(mocks.headMock).toHaveBeenCalledWith('http://example.com')
-    })
-
     it('should return the response from axios.head', async () => {
       const response = { headers: { 'content-length': '1' } }
       mocks.headMock.mockImplementation(() => response)
-      expect(await SubmitUrlController.getHeadRequest('http://example.com')).toBe(response)
+      expect(await SubmitUrlController.headRequest('http://example.com')).toBe(response)
     })
   })
 


### PR DESCRIPTION
Fixes #183 

The web server did not like the (default) 'User-Agent' header we passed and trying to access the URL resulted in 403 error. 
This PR passes a 'check service' string as 'User-Agent'. 

Also: 
- renamed the awkwardly named fn to `headRequets`
- run some of the URL validators _before_ firing the HEAD request