### PR TITLE
Fix URL to have the correct params

### DIFF
--- a/src/controllers/OrganisationsController.js
+++ b/src/controllers/OrganisationsController.js
@@ -492,10 +492,10 @@ const organisationsController = {
     const datasetId = req.params.dataset
 
     try {
-      const organisationResult = await datasette.runQuery(`SELECT name, organisation FROM organisation WHERE organisation = '${lpa}'`)
+      const organisationResult = await datasette.runQuery(`SELECT name, organisation, statistical_geography FROM organisation WHERE organisation = '${lpa}'`)
       const organisation = organisationResult.formattedData[0]
 
-      const datasetResult = await datasette.runQuery(`SELECT name FROM dataset WHERE dataset = '${datasetId}'`)
+      const datasetResult = await datasette.runQuery(`SELECT dataset, name FROM dataset WHERE dataset = '${datasetId}'`)
       const dataset = datasetResult.formattedData[0]
 
       const issues = await performanceDbApi.getLpaDatasetIssues(lpa, datasetId)

--- a/src/routes/schemas.js
+++ b/src/routes/schemas.js
@@ -38,7 +38,7 @@ const datasetStatusEnum = {
   'Not submitted': 'Not submitted'
 }
 
-const OrgField = v.strictObject({ name: NonEmptyString, organisation: NonEmptyString })
+const OrgField = v.strictObject({ name: NonEmptyString, organisation: NonEmptyString, statistical_geography: v.optional(NonEmptyString) })
 const DatasetNameField = v.strictObject({ name: NonEmptyString })
 
 export const OrgOverviewPage = v.strictObject({
@@ -80,6 +80,7 @@ export const OrgDatasetTaskList = v.strictObject({
   })),
   organisation: OrgField,
   dataset: v.strictObject({
+    dataset: v.optional(NonEmptyString),
     name: NonEmptyString
   })
 })

--- a/src/views/organisations/datasetTaskList.html
+++ b/src/views/organisations/datasetTaskList.html
@@ -50,7 +50,7 @@
     <p>There are no issues with {{ organisation.name }}'s {{ dataset.name }} dataset.</p>
 
     <p><a
-        href="https://www.planning.data.gov.uk/entity/?dataset=brownfield-land&geometry_curie=statistical-geography:E07000091">View
+        href="https://www.planning.data.gov.uk/entity/?dataset={{ dataset.dataset }}&geometry_curie=statistical-geography:{{ organisation.statistical_geography }}">View
         the dataset on the Planning Data platform</a></p>
 
     {% else %}

--- a/test/unit/datasetTaskListPage.test.js
+++ b/test/unit/datasetTaskListPage.test.js
@@ -102,8 +102,8 @@ describe('Dataset Task List Page', () => {
   })
 
   it('renders correctly when no taskList items are passed in', () => {
-    const organisation = { name: 'Test Organisation' }
-    const dataset = { name: 'Test Dataset' }
+    const organisation = { name: 'Test Organisation', statistical_geography: '12345678' }
+    const dataset = { name: 'Test Dataset', dataset: 'test-dataset' }
     const taskList = []
 
     const html = nunjucks.render('organisations/datasetTaskList.html', {
@@ -113,7 +113,9 @@ describe('Dataset Task List Page', () => {
     })
 
     const paragraphText = `There are no issues with ${organisation.name}'s ${dataset.name} dataset.`
+    const linkHref = `https://www.planning.data.gov.uk/entity/?dataset=${dataset.dataset}&geometry_curie=statistical-geography:${organisation.statistical_geography}`
 
     expect(html).toContain(paragraphText)
+    expect(html).toContain(linkHref)
   })
 })


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Previously params were hardcoded therefore they always went to the same location.

This change fixes it so that it dynamically changes based on the page context.

## Related Tickets & Documents

- Ticket Link - https://github.com/digital-land/submit/issues/321
- Closes #321

## QA Instructions, Screenshots, Recordings

1. Go to https://check.planning.data.gov.uk/organisations/local-authority:BNE/article-4-direction
1. Click on `View the dataset on the Planning Data platform` link

## Added/updated tests?

- [x] Yes