### PR TITLE
point re-submit link on error page to 'get-started' page

### DIFF
--- a/src/views/organisations/http-error.html
+++ b/src/views/organisations/http-error.html
@@ -5,6 +5,7 @@
 
 {% set pageName %}{{organisation.name}} - {{dataset.name}} - Task list{% endset %}
 {% set serviceType = 'manage' %}
+{% set resubmitUrl %}/organisations/{{ organisation.organisation | urlencode }}/{{ dataset.name | urlencode }}/get-started{% endset %}
 
 {% block beforeContent %}
 
@@ -86,7 +87,7 @@
       ]
     }) }}
 
-    <p>If your data URL has changed you can <a href="/submit">resubmit your data URL</a>.</p>
+    <p>If your data URL has changed you can <a class="resubmit-link" href="{{ resubmitUrl }}">resubmit your data URL</a>.</p>
 
     <p>You should try to make sure your data URLs stay the same when you update your data so we can collect your data
       each night.</p>

--- a/test/unit/http-errorPage.test.js
+++ b/test/unit/http-errorPage.test.js
@@ -1,31 +1,18 @@
 import { describe, it, expect } from 'vitest'
-import nunjucks from 'nunjucks'
-import addFilters from '../../src/filters/filters'
+import { setupNunjucks } from '../../src/serverSetup/nunjucks.js'
 import { JSDOM } from 'jsdom'
 import { runGenericPageTests } from './generic-page.js'
 
-const nunjucksEnv = nunjucks.configure([
-  'src/views',
-  'src/views/check',
-  'src/views/submit',
-  'node_modules/govuk-frontend/dist/',
-  'node_modules/@x-govuk/govuk-prototype-components/'
-], {
-  dev: true,
-  noCache: true,
-  watch: true
-})
-
-const datasetNameMapping = new Map()
-addFilters(nunjucksEnv, { datasetNameMapping })
+const nunjucks = setupNunjucks({ datasetNameMapping: new Map() })
 
 describe('http-error.html', () => {
   const params = {
     organisation: {
-      name: 'mock org'
+      name: 'mock org',
+      organisation: 'mock-org'
     },
     dataset: {
-      name: 'mock dataset'
+      name: 'mock-dataset'
     },
     errorData: {
       endpoint_url: 'https://example.com/data-url',
@@ -40,7 +27,7 @@ describe('http-error.html', () => {
   const document = dom.window.document
 
   runGenericPageTests(html, {
-    pageTitle: 'mock org - mock dataset - Task list - Submit and update your planning data'
+    pageTitle: 'mock org - mock-dataset - Task list - Submit and update your planning data'
   })
 
   it('Renders the correct heading', () => {
@@ -64,5 +51,10 @@ describe('http-error.html', () => {
 
     expect(rows[3].querySelector('.govuk-summary-list__key').textContent).toContain('Last successful access')
     expect(rows[3].querySelector('.govuk-summary-list__value').textContent).toMatch(/\d{1,2} [A-Za-z]{3,9} \d{4} at \d{1,2}(am|pm)/)
+  })
+
+  it('re-submit link points to get-started page', () => {
+    const resubmitLink = document.querySelector('a.resubmit-link')
+    expect(resubmitLink.getAttribute('href')).toBe(`/organisations/${params.organisation.organisation}/${params.dataset.name}/get-started`)
   })
 })


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The http-error.html template contains a re-submit link that points to the submit service. We should change it to point to the 'get started' page.

## Related Tickets & Documents

Closes #351 
https://github.com/digital-land/submit/issues/346

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
