### PR TITLE
make check service User-Agent header value configurable

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -24,6 +24,10 @@ serviceNames: {
     check: 'Check planning and housing data for England',
     manage: 'Submit and update your planning data'
 }
+checkService:
+    # used as User-Agent header when checking the accessibility
+    # of user supplied URLs
+    userAgent: 'GOVUK Planning Data: Check Service'
 templateContent:
     feedbackLink: 'https://docs.google.com/forms/d/e/1FAIpQLSdYXqY0Aaket9XJBiGDhSL_CD_cxHZxgvQCFZZtdURdvvIY5A/viewform'
     homepageUrl: '/'

--- a/config/index.js
+++ b/config/index.js
@@ -3,7 +3,7 @@ import { combineConfigs, validateConfig } from './util.js'
 
 /**
  *
- * @returns {{defaultConfig, environment, url}}
+ * @returns {{defaultConfig, environment, url, checkService: { userAgent: string }}}
  */
 const getConfig = () => {
   const environment = process.env.NODE_ENV || process.env.ENVIRONMENT || 'production'

--- a/config/util.js
+++ b/config/util.js
@@ -36,6 +36,9 @@ export const ConfigSchema = v.object({
     submit: NonEmptyString,
     manage: NonEmptyString
   }),
+  checkService: v.object({
+    userAgent: NonEmptyString
+  }),
   templateContent: v.object({
     feedbackLink: v.url(),
     homepageUrl: NonEmptyString // relative link, e.g. '/manage

--- a/src/controllers/submitUrlController.js
+++ b/src/controllers/submitUrlController.js
@@ -94,7 +94,7 @@ class SubmitUrlController extends UploadController {
    */
   static async headRequest (url) {
     try {
-      return await axios.head(url, { headers: { 'User-Agent': 'check service' } })
+      return await axios.head(url, { headers: { 'User-Agent': config.checkService.userAgent } })
     } catch (err) {
       const response = err?.response
       if (response) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This moves the recently introduced User-Agent header we pass in requests (to verify accessibility of a user supplied URL) to the config file and replaces "check service" value with "GOVUK Planning Data: Check Service" (suggested by @DilwoarH )

## Related Tickets & Documents

No ticket. Builds on #344 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No - 1) not worth it, only (some) external services care about this header 2) config validation tests exercise the config change.
- [ ] I need help with writing tests
