### PR TITLE
downgrade govuk filters markdown dependency and modify filter code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@sentry/node": "^8.7.0",
         "@sentry/profiling-node": "^8.7.0",
         "@x-govuk/govuk-prototype-components": "^3.0.5",
-        "@x-govuk/govuk-prototype-filters": "^1.4.1",
+        "@x-govuk/govuk-prototype-filters": "github:GeorgeGoodall/govuk-prototype-filters#fix/markdownFilterStackOverflow",
         "accessible-autocomplete": "^3.0.0",
         "aws-sdk": "^2.1581.0",
         "axios": "^1.6.2",
@@ -3326,8 +3326,7 @@
     },
     "node_modules/@x-govuk/govuk-prototype-filters": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@x-govuk/govuk-prototype-filters/-/govuk-prototype-filters-1.4.1.tgz",
-      "integrity": "sha512-ykybsndEUMEZuBWb1da0J6NkTXjf2Trn1TlZYaFGNF8aFiYWV3yiHIByyBgdJ4xY9rsIWyDdkZaW+uTi0hxR4A==",
+      "resolved": "git+ssh://git@github.com/GeorgeGoodall/govuk-prototype-filters.git#ffa06d6fba532ac8ead182ac6a87c375ed9404bd",
       "dependencies": {
         "govuk-markdown": "^0.7.0",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@sentry/node": "^8.7.0",
     "@sentry/profiling-node": "^8.7.0",
     "@x-govuk/govuk-prototype-components": "^3.0.5",
-    "@x-govuk/govuk-prototype-filters": "^1.4.1",
+    "@x-govuk/govuk-prototype-filters": "github:GeorgeGoodall/govuk-prototype-filters#fix/markdownFilterStackOverflow",
     "accessible-autocomplete": "^3.0.0",
     "aws-sdk": "^2.1581.0",
     "axios": "^1.6.2",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- Bug Fix

## Description
This ticket changes the dependency source for [govuk_prototype_filters](https://github.com/x-govuk/govuk-prototype-filters) to use [our fork](https://github.com/GeorgeGoodall/govuk-prototype-filters/tree/fix/markdownFilterStackOverflow) which has had two changes compared to the upstream repo: 
- A fix for the stack overflow issue in the govuk_markdown filter
- downgraded version of marked tp v13 as marked v14 seems to break stuff

the reason we are using a fork and not just contributing to the upstream repo is because it has failing tests from a recent commit. We have opened a [PR](https://github.com/x-govuk/govuk-prototype-filters/pull/81), but can't get it approved due to failing tests anyway

## Related Tickets & Documents
- Related Issue: #313 

## Added/updated tests?
No, and this is why: _only a dependency change_