### PR TITLE
Visualise geospatial data on dataset issues page

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "prepare": "husky",
+    "dev": "docker-compose -f docker-compose-real-backend-minus-frontend.yml up -d && npm run start:local",
     "start": "node index.js",
     "start:watch": "concurrently \"nodemon --exec 'npm run build && npm run start'\" \"npm run scss:watch\"",
     "start:test": "NODE_ENV=test node index.js",

--- a/readme.md
+++ b/readme.md
@@ -23,9 +23,7 @@ This is the frontend for the LPA Data Validator application. It is a nodeJS expr
 **Prerequisite**: Install [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 
 ```sh
-docker-compose -f docker-compose-real-backend-minus-frontend.yml up -d;
-
-npm run start:local;
+npm run dev
 ```
 
 ### Alternative methods of starting application

--- a/src/assets/js/map.js
+++ b/src/assets/js/map.js
@@ -6,7 +6,8 @@ class Map {
     this.map = new maplibregl.Map({
       container: containerId,
       style: 'https://api.maptiler.com/maps/basic-v2/style.json?key=ncAXR9XEn7JgHBLguAUw',
-      zoom: 11
+      zoom: 11,
+      center: [-0.1298779, 51.4959698]
     })
 
     this.map.on('load', () => {

--- a/src/assets/js/map.js
+++ b/src/assets/js/map.js
@@ -2,12 +2,13 @@ import parse from 'wellknown'
 import maplibregl from 'maplibre-gl'
 
 class Map {
-  constructor (containerId, geometries) {
+  constructor (containerId, geometries, interactive = true) {
     this.map = new maplibregl.Map({
       container: containerId,
       style: 'https://api.maptiler.com/maps/basic-v2/style.json?key=ncAXR9XEn7JgHBLguAUw',
       zoom: 11,
-      center: [-0.1298779, 51.4959698]
+      center: [-0.1298779, 51.4959698],
+      interactive
     })
 
     this.map.on('load', () => {
@@ -119,7 +120,7 @@ class Map {
 }
 
 const createMapFromServerContext = () => {
-  const { containerId, geometries } = window.serverContext
+  const { containerId, geometries, mapType } = window.serverContext
 
   // if any of the required properties are missing, return null
   if (!containerId || !geometries) {
@@ -127,7 +128,7 @@ const createMapFromServerContext = () => {
     return null
   }
 
-  return new Map(containerId, geometries)
+  return new Map(containerId, geometries, mapType !== 'static')
 }
 
 const newMap = createMapFromServerContext()

--- a/src/controllers/OrganisationsController.js
+++ b/src/controllers/OrganisationsController.js
@@ -448,9 +448,11 @@ function prepareIssueDetailsTemplateParams (req, res, next) {
     }
   }
 
+  const geometries = entryData.filter(row => row.field === 'geometry').map(row => row.value)
   const entry = {
     title: `entry: ${entryNumber}`,
-    fields
+    fields,
+    geometries
   }
 
   const paginationObj = {}

--- a/src/filters/pluralise.js
+++ b/src/filters/pluralise.js
@@ -1,5 +1,0 @@
-import pluralize from 'pluralize'
-
-export const pluralise = (word, count = 1) => {
-  return pluralize(word, count)
-}

--- a/src/routes/schemas.js
+++ b/src/routes/schemas.js
@@ -114,7 +114,8 @@ export const OrgIssueDetails = v.strictObject({
       key: v.strictObject({ text: NonEmptyString }),
       value: v.strictObject({ html: v.string() }),
       classes: v.string()
-    }))
+    })),
+    geometries: v.optional(v.array(v.string()))
   }),
   pagination: v.optional(v.strictObject({
     previous: v.optional(v.strictObject({

--- a/src/views/organisations/issueDetails.html
+++ b/src/views/organisations/issueDetails.html
@@ -57,6 +57,15 @@
       errorList: issueItems
     }) }}
 
+    {% if entry.geometries %}
+      <div
+        id="map"
+        class="app-map"
+        role="region"
+        aria-label="Static map showing {{dataset.name}} for {{organisation.name}}.">
+      </div>
+    {% endif %}
+
     {{ govukSummaryList({
       card: {
         title: {
@@ -86,4 +95,18 @@
     </ol>
   </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  {% if entry.geometries %}
+    <link href='https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css' rel='stylesheet' />
+    <script>
+      window.serverContext = {
+        containerId: 'map',
+        geometries: {{ entry.geometries | dump | safe }},
+      }
+    </script>
+    <script src="/public/js/map.bundle.js"></script>
+  {% endif %}
 {% endblock %}

--- a/src/views/organisations/issueDetails.html
+++ b/src/views/organisations/issueDetails.html
@@ -105,6 +105,7 @@
       window.serverContext = {
         containerId: 'map',
         geometries: {{ entry.geometries | dump | safe }},
+        mapType: "static"
       }
     </script>
     <script src="/public/js/map.bundle.js"></script>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Displaying geospatial data on a map enables LPAs to visually check that the data they've provided is correct. A key finding from the Alpha phase was that this approach had much better responses than just displaying the data in a list or table format, as they'd be able to visually check the boundaries and locations were correct.

## Related Tickets & Documents

- Closes #388

## QA Instructions, Screenshots, Recordings

Acceptance criteria:
- As a data provider, when I'm viewing the issues page of a dataset that contains geospatial data, I can see the geospatial data for each entity displayed on a static map.
- As a data provider, when I'm viewing the issues page of a dataset that contains geospatial data, and I click through each entity listed, the map changes to display the geospatial data for that particular entity.

## Before

![screenshot-localhost_5000-2024_09_08-08_03_54](https://github.com/user-attachments/assets/3ba0ffd2-1201-4a2d-ae3f-453b237b5a69)

## After

![screenshot-localhost_5000-2024_09_08-08_02_53](https://github.com/user-attachments/assets/313bfa97-8a2c-44c1-bc50-76aac0637608)

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests