### PR TITLE
handle GeoX, GeoY columns in input data.

### DIFF
--- a/src/models/requestData.js
+++ b/src/models/requestData.js
@@ -3,9 +3,14 @@ import axios from 'axios'
 import config from '../../config/index.js'
 import ResponseDetails from './responseDetails.js'
 
-export default class RequestData {
-  constructor (response) {
-    Object.assign(this, response)
+/**
+ * Holds response data of 'http://ASYNC-REQUEST-API-HOST/requests/:result-id' endpoint.
+ *
+ * Allows to get the result details by invoking {@link fetchResponseDetails}
+ */
+export default class ResultData {
+  constructor (responseData) {
+    Object.assign(this, responseData)
   }
 
   async fetchResponseDetails (pageNumber = 0, limit = 50, severity = undefined) {
@@ -16,15 +21,15 @@ export default class RequestData {
       urlParams.append('jsonpath', `$.issue_logs[*].severity=="${severity}"`)
     }
 
-    const request = await axios.get(`${config.asyncRequestApi.url}/${config.asyncRequestApi.requestsEndpoint}/${this.id}/response-details?${urlParams.toString()}`, { timeout: 30000 })
+    const response = await axios.get(`${config.asyncRequestApi.url}/${config.asyncRequestApi.requestsEndpoint}/${this.id}/response-details?${urlParams.toString()}`, { timeout: 30000 })
 
     const pagination = {
-      totalResults: request.headers['x-pagination-total-results'],
-      offset: request.headers['x-pagination-offset'],
-      limit: request.headers['x-pagination-limit']
+      totalResults: response.headers['x-pagination-total-results'],
+      offset: response.headers['x-pagination-offset'],
+      limit: response.headers['x-pagination-limit']
     }
 
-    return new ResponseDetails(this.id, request.data, pagination, this.getColumnFieldLog())
+    return new ResponseDetails(this.id, response.data, pagination, this.getColumnFieldLog())
   }
 
   getErrorSummary () {
@@ -69,6 +74,10 @@ export default class RequestData {
     return finishedProcessingStatuses.includes(this.status)
   }
 
+  /**
+   *
+   * @returns {any[]}
+   */
   getColumnFieldLog () {
     if (!this.response || !this.response.data || !this.response.data['column-field-log']) {
       logger.warn('trying to get column field log when there is none', { requestId: this.id })

--- a/src/services/asyncRequestApi.js
+++ b/src/services/asyncRequestApi.js
@@ -1,6 +1,7 @@
 import axios from 'axios'
 import config from '../../config/index.js'
-import RequestData from '../models/requestData.js'
+import ResultData from '../models/requestData.js'
+import logger from '../utils/logger.js'
 
 const requestsEndpoint = `${config.asyncRequestApi.url}/${config.asyncRequestApi.requestsEndpoint}`
 
@@ -19,7 +20,7 @@ export const postFileRequest = async (formData) => {
 
 export const postUrlRequest = async (formData) => {
   const { url, dataset, collection, geomType } = formData
-
+  logger.debug('postUrlRequest', { url, dataset, collection, geomType })
   return await postRequest({
     dataset,
     collection,
@@ -56,7 +57,7 @@ export const getRequestData = async (resultId) => {
   try {
     const response = await axios.get(`${config.asyncRequestApi.url}/${config.asyncRequestApi.requestsEndpoint}/${resultId}`)
 
-    return new RequestData(response.data)
+    return new ResultData(response.data)
   } catch (error) {
     throw new Error(`HTTP error! status: ${error.status}`)
   }

--- a/src/views/check/results/no-errors.html
+++ b/src/views/check/results/no-errors.html
@@ -155,4 +155,3 @@
     <script src="/public/js/map.bundle.js"></script>
   {% endif %}
 {% endblock %}
-```

--- a/test/unit/responseDetails.test.js
+++ b/test/unit/responseDetails.test.js
@@ -43,6 +43,11 @@ describe('ResponseDetails', () => {
     }
   ]
 
+  const mockResponsWithGeoXGeoY = mockResponse.map(({ converted_row: row, ...entry }, i) => {
+    const { geometry, ...other } = row
+    return { ...entry, converted_row: { ...other, GeoX: `123.4${i}`, GeoY: `123.4${i}` } }
+  })
+
   const mockPagination = {
     totalResults: 2,
     offset: 0,
@@ -251,7 +256,7 @@ describe('ResponseDetails', () => {
     it('returns null if there are no geometries', () => {
       const responseDetails = new ResponseDetails(undefined, [], undefined, undefined)
       const result = responseDetails.getGeometries()
-      expect(result).toBeNull()
+      expect(result).toBeUndefined()
     })
 
     it('returns an array of geometries', () => {
@@ -266,6 +271,17 @@ describe('ResponseDetails', () => {
       const expected = [
         'POINT (423432.0000000000000000 564564.0000000000000000)',
         'POINT (423432.0000000000000000 564564.0000000000000000)'
+      ]
+      expect(result).toEqual(expected)
+    })
+
+    it('handles Geox, GeoY columns', () => {
+      const mockColumnFieldLog = []
+      const responseDetails = new ResponseDetails(undefined, mockResponsWithGeoXGeoY, undefined, mockColumnFieldLog)
+      const result = responseDetails.getGeometries()
+      const expected = [
+        'POINT (123.40 123.40)',
+        'POINT (123.41 123.41)'
       ]
       expect(result).toEqual(expected)
     })


### PR DESCRIPTION
## What type of PR is this? 

- [x] Feature

## Description

`ResponseDetails.getGeometries()` returns array of `"POINT (X Y)"` when geometry data is stored in a pair of columns: `GeoX` and `GeoY`.

## Related Tickets & Documents

There async-request-api made changes recently that can potentially help us with the above (see https://github.com/digital-land/async-request-backend/pull/41), but not in this particular PR.

We don't make use of the new 'transformed_row' entry in the body of '/requests/:result-id/response-details' response (of async api), because that entry is present only when 'dataset=brownfield-land' is passed as param. We currently don't support 'brownfield-land' datasets, so that's not available in to us.

Instead, 'POINT' value is extracted manually from the GeoX, GeoY columns (when present).

- Closes #310 

## Added/updated tests?

- [x] Yes
