### PR TITLE
Hide map when no geometries are passed in

### DIFF
--- a/src/views/organisations/issueDetails.html
+++ b/src/views/organisations/issueDetails.html
@@ -57,7 +57,7 @@
       errorList: issueItems
     }) }}
 
-    {% if entry.geometries %}
+    {% if entry.geometries and entry.geometries.length %}
       <div
         id="map"
         class="app-map"
@@ -99,7 +99,7 @@
 
 {% block scripts %}
   {{ super() }}
-  {% if entry.geometries %}
+  {% if entry.geometries and entry.geometries.length %}
     <link href='https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css' rel='stylesheet' />
     <script>
       window.serverContext = {

--- a/test/unit/issueDetailsPage.test.js
+++ b/test/unit/issueDetailsPage.test.js
@@ -233,4 +233,50 @@ describe('issueDetails.html', () => {
       })
     })
   })
+
+  describe('Dataset visualisation: Maps', () => {
+    it('should render a map when geometries are passed in', () => {
+      const paramWithGeometry = {
+        organisation,
+        dataset,
+        errorHeading,
+        issueItems,
+        entry: {
+          ...entry,
+          geometries: ['POINT(0 0)']
+        },
+        issueType
+      }
+
+      const mapHtml = nunjucks.render('organisations/issueDetails.html', paramWithGeometry)
+      const mapDom = new JSDOM(mapHtml)
+      const mapDocument = mapDom.window.document
+      const map = mapDocument.querySelector('#map')
+
+      expect(map).not.toBeNull()
+      expect(map.getAttribute('role')).toEqual('region')
+      expect(map.getAttribute('aria-label')).toEqual('Static map showing mock Dataset for mock org.')
+    })
+
+    it('should not render a map when no geometries are passed in', () => {
+      const paramWithGeometry = {
+        organisation,
+        dataset,
+        errorHeading,
+        issueItems,
+        entry: {
+          ...entry,
+          geometries: []
+        },
+        issueType
+      }
+
+      const mapHtml = nunjucks.render('organisations/issueDetails.html', paramWithGeometry)
+      const mapDom = new JSDOM(mapHtml)
+      const mapDocument = mapDom.window.document
+      const map = mapDocument.querySelector('#map')
+
+      expect(map).toBeNull()
+    })
+  })
 })


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes a bug where map would still show if no geometries are passed in. This causes a JS exception and the map to show unintentionally.

## Related Tickets & Documents

- Closes #414 

## QA Instructions, Screenshots, Recordings

### Before

![screenshot-submit_planning_data_gov_uk-2024_09_11-17_50_29](https://github.com/user-attachments/assets/fee66c50-5a48-4650-853f-e7fc3b9a9c21)

### After

![screenshot-localhost_5000-2024_09_11-17_50_06](https://github.com/user-attachments/assets/fed8649e-f17b-40f2-ba5f-5e96a064e351)

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
