### PR TITLE
NOTICKET: fix wrong referenece to resource id

### DIFF
--- a/src/controllers/OrganisationsController.js
+++ b/src/controllers/OrganisationsController.js
@@ -206,7 +206,7 @@ async function fetchEntry (req, res, next) {
     Object.values(issuesByEntryNumber)[pageNum - 1][0].entry_number
 
   req.entryData = await performanceDbApi.getEntry(
-    req.resourceId,
+    req.resource.resource,
     entityNum,
     datasetId
   )

--- a/test/unit/organisationsController.test.js
+++ b/test/unit/organisationsController.test.js
@@ -277,7 +277,7 @@ describe('OrganisationsController.js', () => {
         dataset,
         entryData,
         issues,
-        resourceId: requestParams.resourceId,
+        resource: { resource: requestParams.resourceId },
         issuesByEntryNumber: {
           1: [
             {
@@ -381,7 +381,7 @@ describe('OrganisationsController.js', () => {
         dataset,
         entryData,
         issues,
-        resourceId: requestParams.resourceId,
+        resource: { resource: requestParams.resourceId },
         issuesByEntryNumber: {
           1: [
             {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Replaces wrong identifier (`resourceId`) with the correct one.

## Related Tickets & Documents

Quick fix, no ticket.

Discovered by @alextea 

> Is it a bug that this page is not showing all the fields? https://submit.planning.data.gov.uk/organisations/local-authority:NSM/article-4-direction/missing%20value/document-url/1

Compare left (bug present) and right (bug fixed) below:

<img width="1579" alt="image" src="https://github.com/user-attachments/assets/282933f5-25a2-4095-a5db-c1dfb51e5fd3">


## Added/updated tests?

- [x] Yes, but no tests are actually triggering this issue. Proper integration tests are needed to catch similar issues in the future.
