### PR TITLE
Issue count change

### DIFF
--- a/src/controllers/submitUrlController.js
+++ b/src/controllers/submitUrlController.js
@@ -22,6 +22,7 @@ class SubmitUrlController extends UploadController {
       }
       logger.info({
         message: 'SubmitUrlController: local validation failed during url submission',
+        endpoint: req.originalUrl,
         error: JSON.stringify(error),
         submittedUrl: `${req.body.url ?? '<no url provided>'}`,
         type: types.DataValidation
@@ -120,7 +121,7 @@ class SubmitUrlController extends UploadController {
     try {
       // if the content length header is not provided, return true
       if (!contentLength) {
-        console.warn(`urlResponseIsNotTooLarge(): response.config.url=${response.config.url}`, { type: types.App, errorMessage: 'Content-Length header not provided' })
+        console.info('urlResponseIsNotTooLarge(): Content-Length header not provided', { type: types.App })
         return true
       }
 

--- a/src/filters/filters.js
+++ b/src/filters/filters.js
@@ -7,7 +7,7 @@ import getFullServiceName from './getFullServiceName.js'
 import { makeDatasetSlugToReadableNameFilter } from './makeDatasetSlugToReadableNameFilter.js'
 import pluralize from 'pluralize'
 
-/** maps dataset status (as returned by performanceDbApi/getLpaOverview()) to a
+/** maps dataset status (as returned by `fetchLpaOverview` middleware to a
  * CSS class used by the govuk-tag component
  */
 const statusToTagClassMapping = {

--- a/src/middleware/issueDetails.middleware.js
+++ b/src/middleware/issueDetails.middleware.js
@@ -250,7 +250,7 @@ export function prepareIssueDetailsTemplateParams (req, res, next) {
       }
     } else {
       return {
-        type: 'item',
+        type: 'number',
         number: item,
         href: `${BaseSubpath}${item}`,
         current: pageNumber === parseInt(item)

--- a/src/middleware/middleware.builders.js
+++ b/src/middleware/middleware.builders.js
@@ -19,7 +19,10 @@ export const FetchOptions = {
      * Use 'dataset' from requets params.
      */
   fromParams: Symbol('from-params'),
-  performanceDb: Symbol('performance-database')
+  /**
+   * Use the performance database
+   */
+  performanceDb: Symbol('performance-db')
 }
 
 const datasetOverride = (val, req) => {

--- a/src/middleware/overview.middleware.js
+++ b/src/middleware/overview.middleware.js
@@ -1,8 +1,9 @@
-import performanceDbApi from '../services/performanceDbApi.js'
+import performanceDbApi, { lpaOverviewQuery } from '../services/performanceDbApi.js'
 import { fetchOrgInfo, logPageError } from './common.middleware.js'
-import { renderTemplate } from './middleware.builders.js'
+import { fetchMany, FetchOptions, parallel, renderTemplate } from './middleware.builders.js'
 import { dataSubjects } from '../utils/utils.js'
 import config from '../../config/index.js'
+import _ from 'lodash'
 
 // get a list of available datasets
 const availableDatasets = Object.values(dataSubjects).flatMap((dataSubject) =>
@@ -12,46 +13,110 @@ const availableDatasets = Object.values(dataSubjects).flatMap((dataSubject) =>
 )
 
 /**
- * Middleware.
+ * Middleware. Updates req with 'lpaOverview'
  *
- * @param {*} req
+ * Relies on {@link config}.
+ *
+ * @param {{ params: { lpa: string }, entityCounts: { dataset: string, resource: string, entityCount?: number }[]}} req
+ */
+const fetchLpaOverview = fetchMany({
+  query: ({ req, params }) => {
+    return lpaOverviewQuery(params.lpa, { datasetsFilter: config.datasetsFilter, entityCounts: req.entityCounts })
+  },
+  dataset: FetchOptions.performanceDb,
+  result: 'lpaOverview'
+})
+
+const fetchLatestResources = fetchMany({
+  query: ({ params }) => {
+    return performanceDbApi.latestResourcesQuery(params.lpa, { datasetsFilter: config.datasetsFilter })
+  },
+  result: 'resourceLookup',
+  dataset: FetchOptions.performanceDb
+})
+
+/**
+ * Updates req with `entityCounts` (of shape `{ resource, dataset}|{ resource, dataset, entityCount }`)
+ *
+ * @param {{ resourceLookup: {resource: string, dataset: string}[] }} req
  * @param {*} res
  * @param {*} next
- * @returns {Promise<*>}
  */
-async function fetchLpaOverview (req, res, next) {
-  const { datasetsFilter } = config
-  try {
-    const overview = await performanceDbApi.getLpaOverview(req.params.lpa, {
-      datasetsFilter
-    })
-    req.lpaOverview = overview
-    next()
-  } catch (error) {
-    next(error)
+const fetchEntityCounts = async (req, res, next) => {
+  const { resourceLookup } = req
+
+  req.entityCounts = await performanceDbApi.getEntityCounts(resourceLookup)
+  next()
+}
+
+/**
+ * For the purpose of displaying single status label on (possibly) many issues,
+ * we want issues with 'worse' status to be weighted higher.
+ */
+const statusOrdering = new Map(['Live', 'Needs fixing', 'Error', 'Not submitted'].map((status, i) => [status, i]))
+
+/**
+ * The overview data can contain multiple rows per dataset
+ * and we want a collection of with one item per dataset,
+ * because that's how we display it on the page.
+ *
+ * @param {object[]} lpaOverview
+ * @returns {object[]}
+ */
+function aggregateOverviewData (lpaOverview) {
+  const grouped = _.groupBy(lpaOverview, 'dataset')
+  const datasets = []
+  for (const [dataset, rows] of Object.entries(grouped)) {
+    let numIssues = 0
+    for (const row of rows) {
+      if (row.status !== 'Needs fixing') {
+        continue
+      }
+      const numFields = (row.fields ?? '').split(',').length
+      if (row.issue_count >= row.entity_count) numIssues += numFields
+      else numIssues += row.issue_count
+    }
+    const info = {
+      slug: dataset,
+      issue_count: numIssues,
+      endpoint: rows[0].endpoint,
+      error: rows[0].error,
+      status: _.maxBy(rows, row => statusOrdering.get(row.status)).status
+    }
+    datasets.push(info)
   }
+  return datasets
+}
+
+/**
+ * Calculates overal "health" of the datasets (not)provided by an organisation.
+ *
+ * @param {[number, number, number]} accumulator
+ * @param {{ endpoint?: string, status: string }} dataset
+ * @returns
+ */
+const orgStatsReducer = (accumulator, dataset) => {
+  if (dataset.endpoint) accumulator[0]++
+  if (dataset.status === 'Needs fixing') accumulator[1]++
+  if (dataset.status === 'Error') accumulator[2]++
+  return accumulator
 }
 
 export function prepareOverviewTemplateParams (req, res, next) {
   const { lpaOverview, orgInfo: organisation } = req
-
-  const datasets = Object.entries(lpaOverview.datasets).map(([key, value]) => {
-    return {
-      slug: key,
-      ...value
-    }
-  })
-
+  const datasets = aggregateOverviewData(lpaOverview)
   // add in any of the missing key 8 datasets
-  const keys = Object.keys(lpaOverview.datasets)
+  const keys = new Set(datasets.map(d => d.slug))
   availableDatasets.forEach((dataset) => {
-    if (!keys.includes(dataset)) {
-      datasets.push({
+    if (!keys.has(dataset)) {
+      const row = {
         slug: dataset,
         endpoint: null,
+        status: 'Not submitted',
         issue_count: 0,
-        status: 'Not submitted'
-      })
+        entity_count: undefined
+      }
+      datasets.push(row)
     }
   })
 
@@ -60,15 +125,7 @@ export function prepareOverviewTemplateParams (req, res, next) {
 
   const totalDatasets = datasets.length
   const [datasetsWithEndpoints, datasetsWithIssues, datasetsWithErrors] =
-      datasets.reduce(
-        (accumulator, dataset) => {
-          if (dataset.endpoint) accumulator[0]++
-          if (dataset.status === 'Needs fixing') accumulator[1]++
-          if (dataset.status === 'Error') accumulator[2]++
-          return accumulator
-        },
-        [0, 0, 0]
-      )
+      datasets.reduce(orgStatsReducer, [0, 0, 0])
 
   req.templateParams = {
     organisation,
@@ -92,7 +149,11 @@ export const getOverview = renderTemplate({
 })
 
 export default [
-  fetchOrgInfo,
+  parallel([
+    fetchOrgInfo,
+    fetchLatestResources]
+  ),
+  fetchEntityCounts,
   fetchLpaOverview,
   prepareOverviewTemplateParams,
   getOverview,

--- a/src/middleware/overview.middleware.js
+++ b/src/middleware/overview.middleware.js
@@ -63,7 +63,10 @@ const statusOrdering = new Map(['Live', 'Needs fixing', 'Error', 'Not submitted'
  * @param {object[]} lpaOverview
  * @returns {object[]}
  */
-function aggregateOverviewData (lpaOverview) {
+export function aggregateOverviewData (lpaOverview) {
+  if (!Array.isArray(lpaOverview)) {
+    throw new Error('lpaOverview should be an array')
+  }
   const grouped = _.groupBy(lpaOverview, 'dataset')
   const datasets = []
   for (const [dataset, rows] of Object.entries(grouped)) {
@@ -72,9 +75,11 @@ function aggregateOverviewData (lpaOverview) {
       if (row.status !== 'Needs fixing') {
         continue
       }
-      const numFields = (row.fields ?? '').split(',').length
-      if (row.issue_count >= row.entity_count) numIssues += numFields
-      else numIssues += row.issue_count
+      if (row.issue_count) {
+        const numFields = (row.fields ?? '').split(',').length
+        if (row.issue_count >= row.entity_count) numIssues += numFields
+        else numIssues += row.issue_count
+      }
     }
     const info = {
       slug: dataset,

--- a/src/routes/schemas.js
+++ b/src/routes/schemas.js
@@ -50,7 +50,10 @@ export const OrgOverviewPage = v.strictObject({
     issue_count: v.optional(v.number()),
     error: v.optional(v.nullable(NonEmptyString)),
     http_error: v.optional(NonEmptyString),
-    issue: v.optional(NonEmptyString)
+    issue: v.optional(NonEmptyString),
+    entity_count: v.optional(v.number()),
+    // synthetic entry, represents a user friendly count (e.g. count missing value in a column as 1 issue)
+    numIssues: v.optional(v.number())
   })),
   totalDatasets: v.integer(),
   datasetsWithEndpoints: v.integer(),

--- a/src/routes/schemas.js
+++ b/src/routes/schemas.js
@@ -28,7 +28,7 @@ export const StartPage = v.object({
 
 /**
  * The values of this enum should match values of the 'status' column
- * in the query in `performanceDbApi.getLpaOverview()`
+ * in the query in `fetchLpaOverview` middleware
  */
 export const datasetStatusEnum = {
   Live: 'Live',

--- a/src/services/performanceDbApi.js
+++ b/src/services/performanceDbApi.js
@@ -111,7 +111,7 @@ export function lpaOverviewQuery (lpa, params) {
     }
   }
   if (entityCountsSelects.length === 0) {
-    // add bogus select, to ensure the resulting SQL will be valid
+    // add bogus select, to ensure the resulting SQL is valid
     entityCountsSelects.push(entityCountSelectFragment('none', 'none', 0))
   }
 

--- a/src/services/performanceDbApi.js
+++ b/src/services/performanceDbApi.js
@@ -155,7 +155,7 @@ SELECT
 FROM 
   reporting_latest_endpoints rle
 LEFT JOIN
-  issue_summary i ON rle.resource = i.resource AND rle.pipeline = i.dataset
+  endpoint_dataset_issue_type_summary i ON rle.resource = i.resource AND rle.pipeline = i.dataset
 LEFT OUTER JOIN
   entity_counts ec ON ec.resource = rle.resource AND ec.dataset = rle.pipeline
 WHERE

--- a/src/services/performanceDbApi.js
+++ b/src/services/performanceDbApi.js
@@ -173,17 +173,6 @@ ORDER BY
  * @default
  */
 export default {
-  /**
-     * Get LPA overview
-     * @param {string} lpa - LPA ID
-     * @param {{datasetsFilter: string[], entityCounts: { dataset: string, resource: string, entityCount?: number}[]}} params
-     * @returns {Promise<LpaOverview>} LPA overview
-     */
-  getLpaOverview: async (lpa, params = {}) => {
-    const query = lpaOverviewQuery(params)
-    const result2 = await datasette.runQuery(query, 'performance')
-    return { datasets: {}, result2 }
-  },
 
   resourceStatusQuery (lpa, datasetId) {
     return /* sql */ `

--- a/src/services/performanceDbApi.js
+++ b/src/services/performanceDbApi.js
@@ -85,9 +85,87 @@ const datasetIssuesQuery = (resource, datasetId) => {
  */
 
 /**
- * @typedef {object} LpaOverview
+ * @typedef {object} LpaOverview // this needs to be updated
  * @property {{ [dataset: string]: Dataset }} datasets
  */
+
+const entityCountSelectFragment = (dataset, resource, entityCount) => `select '${dataset}' as d, '${resource}' as r, ${entityCount} as e`
+
+/**
+ *
+ * @param {string} lpa
+ * @param {{datasetsFilter: string[], entityCounts: { dataset: string, resource: string, entityCount?: number}[]}} params
+ * @returns
+ */
+export function lpaOverviewQuery (lpa, params) {
+  let datasetClause = ''
+  if (params.datasetsFilter) {
+    const datasetString = params.datasetsFilter.map(dataset => `'${dataset}'`).join(',')
+    datasetClause = `AND rle.pipeline in (${datasetString})`
+  }
+
+  const entityCountsSelects = []
+  for (const { resource, dataset, entityCount } of params.entityCounts) {
+    if (entityCount && entityCount >= 0) {
+      entityCountsSelects.push(entityCountSelectFragment(dataset, resource, entityCount))
+    }
+  }
+  if (entityCountsSelects.length === 0) {
+    // add bogus select, to ensure the resulting SQL will be valid
+    entityCountsSelects.push(entityCountSelectFragment('none', 'none', 0))
+  }
+
+  return /* sql */`
+with entity_counts as (
+select d as dataset, r as resource, e as entity_count
+from (
+  ${entityCountsSelects.join(' union ')}
+)
+)
+SELECT
+  REPLACE(rle.organisation, '-eng', '') as organisation,
+  rle.name,
+  rle.pipeline as dataset,
+  rle.endpoint,
+  rle.resource,
+  rle.exception,
+  rle.status as http_status,
+  coalesce(ec.entity_count, 0) as entity_count,
+  i.count_issues as issue_count,
+  i.responsibility,
+  i.fields,
+  case
+      when (rle.status is null) then 'Not submitted'
+      when (rle.status != '200') then 'Error'
+      when (i.severity = 'error') then 'Needs fixing'
+      else 'Live'
+  end as status,
+  case
+      when ((cast(rle.status as integer) > 200)) then format('There was a %s error accessing the data URL', rle.status)
+      else null
+  end as error,
+  case
+      when (i.severity = 'info') then ''
+      else i.issue_type
+  end as issue_type,
+  case
+      when (i.severity = 'info') then ''
+      else i.severity
+  end as severity
+FROM 
+  reporting_latest_endpoints rle
+LEFT JOIN
+  issue_summary i ON rle.resource = i.resource AND rle.pipeline = i.dataset
+LEFT OUTER JOIN
+  entity_counts ec ON ec.resource = rle.resource AND ec.dataset = rle.pipeline
+WHERE
+  REPLACE(rle.organisation, '-eng', '') = '${lpa}'
+  AND (i.severity is NULL OR i.severity not in ('info'))
+  ${datasetClause}
+ORDER BY
+  rle.organisation,
+  rle.name;`
+}
 
 /**
  * Performance DB API service
@@ -98,93 +176,13 @@ export default {
   /**
      * Get LPA overview
      * @param {string} lpa - LPA ID
+     * @param {{datasetsFilter: string[], entityCounts: { dataset: string, resource: string, entityCount?: number}[]}} params
      * @returns {Promise<LpaOverview>} LPA overview
      */
   getLpaOverview: async (lpa, params = {}) => {
-    let datasetClause = ''
-    if (params.datasetsFilter) {
-      const datasetString = params.datasetsFilter.map(dataset => `'${dataset}'`).join(',')
-      datasetClause = `AND rle.pipeline in (${datasetString})`
-    }
-
-    const query =
-    /* sql */
-    `
-    SELECT
-    p.organisation,
-    o.name,
-    p.dataset,
-    rle.pipeline,
-    rle.endpoint,
-    rle.resource,
-    rle.exception,
-    rle.status as http_status,
-  case
-      when (rle.status is null) then 'Not Submitted'
-      when (rle.status != '200') then 'Error'
-      when (it.severity = 'error') then 'Needs fixing'
-      else 'Live'
-  end as status,
-    case
-        when ((cast(rle.status as integer) > 200)) then format('There was a %s error accessing the data URL', rle.status)
-        else null
-  end as error,
-  case
-      when (it.severity = 'info') then ''
-      else i.issue_type
-  end as issue_type,
-  case
-      when (it.severity = 'info') then ''
-      else it.severity
-  end as severity,
-  it.responsibility,
-  COUNT(
-      case
-      when it.severity != 'info' and it.severity != 'warning' then 1
-      else null
-      end
-  ) as issue_count
-FROM
-    provision p
-LEFT JOIN
-    organisation o ON o.organisation = p.organisation
-LEFT JOIN
-    reporting_latest_endpoints rle
-    ON REPLACE(rle.organisation, '-eng', '') = p.organisation
-    AND rle.pipeline = p.dataset
-LEFT JOIN
-    issue i ON rle.resource = i.resource AND rle.pipeline = i.dataset
-LEFT JOIN
-    issue_type it ON i.issue_type = it.issue_type AND it.severity != 'info'
-WHERE
-    p.organisation = '${lpa}'
-    ${datasetClause}
-GROUP BY
-    p.organisation,
-    p.dataset,
-    o.name,
-    rle.pipeline,
-    rle.endpoint
-ORDER BY
-    p.organisation,
-    o.name;
-`
-    const result = await datasette.runQuery(query)
-    if (result.formattedData.length === 0) {
-      logger.info(`No records found for LPA=${lpa}`)
-    }
-
-    const datasets = result.formattedData.reduce((accumulator, row) => {
-      accumulator[row.dataset] = {
-        endpoint: row.endpoint,
-        status: row.status,
-        issue_count: row.issue_count,
-        error: row.error
-      }
-      return accumulator
-    }, {})
-
-    return { datasets }
+    const query = lpaOverviewQuery(params)
+    const result2 = await datasette.runQuery(query, 'performance')
+    return { datasets: {}, result2 }
   },
 
   resourceStatusQuery (lpa, datasetId) {
@@ -288,6 +286,55 @@ ORDER BY
     const result = await datasette.runQuery(sql)
 
     return result.formattedData[0]
+  },
+
+  /**
+   * Query for obtaining resource ids for given datasets
+   *
+   * @param {*} lpa
+   * @param {{datasetsFilter: string[]}} params
+   * @returns {string} SQL
+   */
+  latestResourcesQuery: (lpa, params) => {
+    let datasetClause = ''
+    if (params.datasetsFilter) {
+      const datasetString = params.datasetsFilter.map(dataset => `'${dataset}'`).join(',')
+      datasetClause = `AND rle.pipeline in (${datasetString})`
+    }
+
+    return /* sql */ `
+    select
+      rle.pipeline as dataset, 
+      rle.resource as resource
+    from reporting_latest_endpoints rle
+    where
+      REPLACE(organisation, '-eng', '') = '${lpa}'
+      ${datasetClause}`
+  },
+
+  /**
+    *
+    * @param {{resource: string, dataset: string}[]} resources
+    * @returns {Promise<{ resource: string, dataset: string, entityCount?: number}[]>}
+    */
+  async getEntityCounts (resources) {
+    const requests = resources.map(({ resource, dataset }) => {
+      const q = datasette.runQuery(this.entityCountQuery(resource), dataset)
+      return q
+        .then(result => {
+          if (result.formattedData.length === 0) {
+            logger.info({ message: 'getEntityCounts(): No results for resource.', resource, dataset, type: types.App })
+            return { resource, dataset }
+          }
+          return { resource, dataset, entityCount: result.formattedData[0].entity_count }
+        })
+        .catch((error) => {
+          logger.warn('getEntityCounts(): could not obtain entity counts. Proceeding without them.',
+            { type: types.App, errorMessage: error.message, errorStack: error.stack })
+          return { resource, dataset }
+        })
+    })
+    return (await Promise.allSettled(requests)).map(p => p.value)
   },
 
   /**

--- a/src/views/organisations/overview.html
+++ b/src/views/organisations/overview.html
@@ -87,7 +87,7 @@
               {% elif dataset.status == 'Error' %}
                 <p>{{dataset.error}}</p>
               {% elif dataset.status == 'Needs fixing' %}
-                <p>There are {{ dataset.issue_count }} {{ "issue" | pluralise(dataset.issue_count) }} in this dataset</p>
+                <p>There {{ "is" | pluralise(dataset.issue_count) }} {{ dataset.issue_count }} {{ "issue" | pluralise(dataset.issue_count) }} in this dataset</p>
               {% else %}
                 <p>Data URL submitted</p>
               {% endif %}

--- a/test/unit/lpaOverviewPage.test.js
+++ b/test/unit/lpaOverviewPage.test.js
@@ -59,8 +59,10 @@ describe(`LPA Overview Page (seed: ${seed})`, () => {
         expectedHint = 'in this dataset'
       } else if (dataset.status === 'Error') {
         expectedHint = dataset.error || ''
-      } else if (dataset.status === 'Error' && dataset.issue_count <= 1) {
-        expectedHint = `There are ${dataset.issue_count} issue in this dataset`
+      } else if (dataset.status === 'Error' && dataset.issue_count === 0) {
+        expectedHint = `There are ${dataset.issue_count} issues in this dataset`
+      } else if (dataset.status === 'Error' && dataset.issue_count === 1) {
+        expectedHint = `There is ${dataset.issue_count} issue in this dataset`
       } else if (dataset.status === 'Error' && dataset.issue_count > 1) {
         expectedHint = `There are ${dataset.issue_count} issues in this dataset`
       }

--- a/test/unit/middleware/issueDetails.middleware.test.js
+++ b/test/unit/middleware/issueDetails.middleware.test.js
@@ -103,7 +103,7 @@ describe('issueDetails.middleware.js', () => {
             current: true,
             href: '/organisations/test-lpa/test-dataset/test-issue-type/test-issue-field/1',
             number: 1,
-            type: 'item'
+            type: 'number'
           }]
         },
         issueEntitiesCount: 1,
@@ -212,7 +212,7 @@ describe('issueDetails.middleware.js', () => {
             current: true,
             href: '/organisations/test-lpa/test-dataset/test-issue-type/test-issue-field/1',
             number: 1,
-            type: 'item'
+            type: 'number'
           }]
         },
         issueEntitiesCount: 1,

--- a/test/unit/middleware/overview.middleware.test.js
+++ b/test/unit/middleware/overview.middleware.test.js
@@ -17,7 +17,6 @@ describe('overview.middleware', () => {
     { endpoint: null, status: 'Needs fixing', dataset: 'dataset2' },
     { endpoint: 'https://example.com', status: 'Error', dataset: 'dataset3' }
   ]
-  // TODO: add test for perfDbApiResponse where 'dataset1' 2+ rows
 
   describe('prepareOverviewTemplateParams', () => {
     it('should render the overview page', async () => {

--- a/test/unit/middleware/overview.middleware.test.js
+++ b/test/unit/middleware/overview.middleware.test.js
@@ -85,6 +85,21 @@ describe('overview.middleware', () => {
       expect(aggregated[0].status).toBe('Error')
       expect(aggregated[1].status).toBe('Needs fixing')
     })
+
+    it('handles multiple fields', () => {
+      const exampleData = [
+        { endpoint: 'https://example.com/2', status: 'Needs fixing', dataset: 'dataset1', entity_count: 5, issue_count: 5, fields: 'foo,bar' },
+        { endpoint: 'https://example.com/2', status: 'Needs fixing', dataset: 'dataset2', entity_count: 5, issue_count: 2, fields: 'baz,qux' }
+      ]
+
+      const aggregated = aggregateOverviewData(exampleData)
+      aggregated.sort((a, b) => a.slug.localeCompare(b.slug))
+
+      expect(aggregated[0].status).toBe('Needs fixing')
+      expect(aggregated[0].issue_count).toBe(2) // 2 columns affected
+      expect(aggregated[1].status).toBe('Needs fixing')
+      expect(aggregated[0].issue_count).toBe(2) // 2 rows affected (in the same two fields)
+    })
   })
 
   describe('getOverview', () => {

--- a/test/unit/performanceDbApi.test.js
+++ b/test/unit/performanceDbApi.test.js
@@ -1,10 +1,5 @@
 import { vi, it, describe, expect, beforeEach } from 'vitest'
-// import { lpaOverviewQuery } from '../../src/services/performanceDbApi'
 import fs from 'fs'
-
-// function lpaOverviewQuery (a, b) {
-//   return ''
-// }
 
 vi.mock('../../config/index.js', () => {
   return {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

We want to change how we calculate the number of issues on the organisation overview page. Specifically we want
-  an issue affecting all rows in a column to be counted as one issue
- a column issue which affects _n_ fileds should be counted as _n_ issues.

## Related Tickets & Documents

Closes #439 

## QA Instructions, Screenshots, Recordings

Examples differences between `main` and this branch.

### North Lincolnshire Council
- prod:  https://submit.planning.data.gov.uk/organisations/local-authority:NLN
- this pr: https://submit-pr-475.herokuapp.com/organisations/local-authority:NLN

<img width="1146" alt="image" src="https://github.com/user-attachments/assets/3c484219-fef4-405e-8027-83139d8a7c38">

### London Borough of Lambeth 
- prod: https://submit.planning.data.gov.uk/organisations/local-authority:LBH
- this pr: https://submit-pr-475.herokuapp.com/organisations/local-authority:LBH

<img width="1207" alt="image" src="https://github.com/user-attachments/assets/6a622415-c1a8-4d49-af50-9189e0716ceb">

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
