### PR TITLE
change to just use inbuilt json and remove JSON 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "hmpo-form-wizard": "^13.0.0",
         "hmpo-i18n": "^6.0.1",
         "js-yaml": "^4.1.0",
-        "json5": "^2.2.3",
         "lodash": "^4.17.21",
         "maplibre-gl": "^4.1.0",
         "multer": "^1.4.5-lts.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "hmpo-form-wizard": "^13.0.0",
     "hmpo-i18n": "^6.0.1",
     "js-yaml": "^4.1.0",
-    "json5": "^2.2.3",
     "lodash": "^4.17.21",
     "maplibre-gl": "^4.1.0",
     "multer": "^1.4.5-lts.1",

--- a/src/middleware/datasetOverview.middleware.js
+++ b/src/middleware/datasetOverview.middleware.js
@@ -2,7 +2,6 @@ import { fetchDatasetInfo, fetchLatestResource, fetchLpaDatasetIssues, fetchOrgI
 import { fetchOne, fetchIf, fetchMany, parallel, renderTemplate, FetchOptions } from './middleware.builders.js'
 import { fetchResourceStatus } from './datasetTaskList.middleware.js'
 import performanceDbApi from '../services/performanceDbApi.js'
-import json5 from 'json5'
 
 const fetchColumnSummary = fetchMany({
   query: ({ params }) => `select * from column_field_summary
@@ -21,7 +20,7 @@ const fetchSpecification = fetchOne({
 
 export const pullOutDatasetSpecification = (req, res, next) => {
   const { specification } = req
-  const collectionSpecifications = json5.parse(specification.json)
+  const collectionSpecifications = JSON.parse(specification.json)
   const datasetSpecification = collectionSpecifications.find((spec) => spec.dataset === req.dataset.dataset)
   req.specification = datasetSpecification
   next()


### PR DESCRIPTION
This should only be deployed at the same time as [this](https://statics.teams.cdn.office.net/evergreen-assets/safelinks/1/atp-safelinks.html)

## What type of PR is this?
- Refactor

## Description
The specification has been updated to store specs as json strings (instead of invalid json strings that use single quotes)
This PR updates the code responsible for parsing this

## Related Tickets & Documents
- Related PR: https://statics.teams.cdn.office.net/evergreen-assets/safelinks/1/atp-safelinks.html
- Closes #491 

## Added/updated tests?
- No

