### PR TITLE
fix issue count

### DIFF
--- a/src/views/organisations/overview.html
+++ b/src/views/organisations/overview.html
@@ -86,7 +86,7 @@
                 <p>Data URL not submitted</p>
               {% elif dataset.status == 'Error' %}
                 <p>{{dataset.error}}</p>
-              {% elif dataset.status == 'Needs fixing' > 0 %}
+              {% elif dataset.status == 'Needs fixing' %}
                 <p>There are {{ dataset.issue_count }} {{ "issue" | pluralise(dataset.issue_count) }} in this dataset</p>
               {% else %}
                 <p>Data URL submitted</p>

--- a/test/unit/lpaOverviewPage.test.js
+++ b/test/unit/lpaOverviewPage.test.js
@@ -55,6 +55,8 @@ describe(`LPA Overview Page (seed: ${seed})`, () => {
       let expectedHint = 'Data URL submitted'
       if (dataset.status === 'Not submitted') {
         expectedHint = 'Data URL not submitted'
+      } else if (dataset.status === 'Needs fixing') {
+        expectedHint = 'in this dataset'
       } else if (dataset.status === 'Error') {
         expectedHint = dataset.error || ''
       } else if (dataset.status === 'Error' && dataset.issue_count <= 1) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

For datasets that "Need fixing" we should display short text summarizing the issue (atm, it's the number of issues). Incorrect condition in the template cause the default 'Data URL submitted' text to be displayed instead.

## Related Tickets & Documents

No ticket.

## QA Instructions, Screenshots, Recordings

This is how it looks in PROD at the moment:

<img width="1015" alt="image" src="https://github.com/user-attachments/assets/8edb9f67-e8d3-4463-a680-72683a4d8789">ges for UI changes._

## Added/updated tests?

- [x] Yes
