### PR TITLE
Adjusts column summary query to use endpoint_dataset_summary table end date

### DIFF
--- a/src/middleware/datasetOverview.middleware.js
+++ b/src/middleware/datasetOverview.middleware.js
@@ -4,10 +4,26 @@ import { fetchResourceStatus } from './datasetTaskList.middleware.js'
 import performanceDbApi from '../services/performanceDbApi.js'
 
 const fetchColumnSummary = fetchMany({
-  query: ({ params }) => `select * from endpoint_dataset_resource_summary
-    where resource != ''
-    and endpoint_end_date = ''
-    and pipeline = '${params.dataset}'
+  query: ({ params }) => `
+    SELECT
+      edrs.*
+    FROM
+      endpoint_dataset_resource_summary edrs
+      INNER JOIN (
+        SELECT
+          endpoint,
+          dataset,
+          organisation,
+          end_date as endpoint_end_date
+        FROM
+          endpoint_dataset_summary
+        WHERE
+          end_date = ''
+      ) as t1 on t1.endpoint = edrs.endpoint
+      AND replace(t1.organisation, '-eng', '') = edrs.organisation
+    WHERE
+    edrs.resource != ''
+    AND pipeline = '${params.dataset}'
     AND organisation = '${params.lpa}'
     limit 1000`,
   result: 'columnSummary',


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adjusts the query used to fetch data from the column summary (now called resource summary) table. It now joins to the endpoint summary table to retrieve endpoint end date data, as this column will be removed from the endpoint_resource_summary table

## Related Tickets & Documents

https://trello.com/c/NJSZQBUZ/3512-perf-db-general-changes

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [X] No, and this is why: No new functionality added
- [ ] I need help with writing tests
