### PR TITLE
Hotfix: Fixes an issue where missing org could down the server if it's run in parallel

### DIFF
--- a/src/middleware/datasetOverview.middleware.js
+++ b/src/middleware/datasetOverview.middleware.js
@@ -111,10 +111,8 @@ const getDatasetOverview = renderTemplate(
 )
 
 export default [
-  parallel([
-    fetchOrgInfo,
-    fetchDatasetInfo
-  ]),
+  fetchOrgInfo,
+  fetchDatasetInfo,
   parallel([
     fetchColumnSummary,
     fetchResourceStatus,

--- a/src/middleware/datasetTaskList.middleware.js
+++ b/src/middleware/datasetTaskList.middleware.js
@@ -113,9 +113,8 @@ const getDatasetTaskListError = renderTemplate({
 
 export default [
   fetchResourceStatus,
-  parallel([
-    fetchOrgInfoWithStatGeo,
-    fetchDatasetInfo]),
+  fetchOrgInfoWithStatGeo,
+  fetchDatasetInfo,
   fetchIf(isResourceAccessible, fetchLatestResource),
   parallel([
     fetchIf(isResourceAccessible, fetchLpaDatasetIssues),

--- a/src/middleware/issueDetails.middleware.js
+++ b/src/middleware/issueDetails.middleware.js
@@ -286,10 +286,8 @@ export const getIssueDetails = renderTemplate({
 
 export default [
   validateIssueDetailsQueryParams,
-  parallel([
-    fetchOrgInfo,
-    fetchDatasetInfo
-  ]),
+  fetchOrgInfo,
+  fetchDatasetInfo,
   fetchIf(isResourceIdInParams, fetchLatestResource, takeResourceIdFromParams),
   fetchIssues,
   reformatIssuesToBeByEntryNumber,

--- a/src/middleware/overview.middleware.js
+++ b/src/middleware/overview.middleware.js
@@ -1,6 +1,6 @@
 import performanceDbApi, { lpaOverviewQuery } from '../services/performanceDbApi.js'
 import { fetchOrgInfo, logPageError } from './common.middleware.js'
-import { fetchMany, FetchOptions, parallel, renderTemplate } from './middleware.builders.js'
+import { fetchMany, FetchOptions, renderTemplate } from './middleware.builders.js'
 import { dataSubjects } from '../utils/utils.js'
 import config from '../../config/index.js'
 import _ from 'lodash'
@@ -154,10 +154,8 @@ export const getOverview = renderTemplate({
 })
 
 export default [
-  parallel([
-    fetchOrgInfo,
-    fetchLatestResources]
-  ),
+  fetchOrgInfo,
+  fetchLatestResources,
   fetchEntityCounts,
   fetchLpaOverview,
   prepareOverviewTemplateParams,


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes an issue where missing org could down the server if it's run in parallel.

The `fallbackPolicy` doesn't end the request therefore leaves the thread open. This causes the server to crash the next time the user refreshes as a new header is being attached after the request was already sent.

This is initial analysis and needs further investigation.

Ref: https://github.com/digital-land/submit/blob/main/src/middleware/middleware.builders.js#L43

This line sends a 404 res return but doesn't close the request.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: Needs further investigation - this is a hotfix
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?