### PR TITLE
531 display brownfield land datasets as an option on the lpa dashboard page

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -44,11 +44,12 @@ validations: {
 datasetsFilter: [
     'article-4-direction',
     'article-4-direction-area',
+    'brownfield-land',
     'conservation-area',
     'conservation-area-document',
     'tree-preservation-order',
     'tree-preservation-zone',
     'tree',
     'listed-building',
-    'listed-building-outline'   
+    'listed-building-outline'
 ]

--- a/src/assets/js/map.js
+++ b/src/assets/js/map.js
@@ -1,11 +1,14 @@
 import parse from 'wellknown'
 import maplibregl from 'maplibre-gl'
 
-const fillColor = '#008'
 const lineColor = '#000000'
+const fillColor = '#008'
+const fillOpacity = 0.4
 const boundaryLineColor = '#f00'
 const boundaryLineOpacity = 1
-const opacity = 0.4
+const pointOpacity = 0.8
+const pointRadius = 5
+const pointColor = '#008'
 
 /**
  * Creates a Map instance.
@@ -97,7 +100,7 @@ class Map {
           layout: {},
           paint: {
             'fill-color': fillColor,
-            'fill-opacity': opacity
+            'fill-opacity': fillOpacity
           }
         }, this.firstMapLayerId)
 
@@ -117,9 +120,9 @@ class Map {
           type: 'circle',
           source: name,
           paint: {
-            'circle-radius': 10,
-            'circle-color': fillColor,
-            'circle-opacity': opacity
+            'circle-radius': pointRadius,
+            'circle-color': pointColor,
+            'circle-opacity': pointOpacity
           }
         }, this.firstMapLayerId)
       }
@@ -143,8 +146,20 @@ class Map {
         layout: {},
         paint: {
           'fill-color': fillColor,
-          'fill-opacity': opacity
+          'fill-opacity': fillOpacity
         }
+      }, this.firstMapLayerId)
+
+      this.map.addLayer({
+        id: `${name}-point`,
+        type: 'circle',
+        source: name,
+        paint: {
+          'circle-radius': pointRadius,
+          'circle-color': pointColor,
+          'circle-opacity': pointOpacity
+        },
+        filter: ['==', '$type', 'Point']
       }, this.firstMapLayerId)
 
       this.map.addLayer({

--- a/src/middleware/datasetOverview.middleware.js
+++ b/src/middleware/datasetOverview.middleware.js
@@ -1,5 +1,5 @@
 import { fetchDatasetInfo, fetchLatestResource, fetchLpaDatasetIssues, fetchOrgInfo, isResourceAccessible, isResourceIdInParams, logPageError, takeResourceIdFromParams } from './common.middleware.js'
-import { fetchOne, fetchIf, fetchMany, parallel, renderTemplate, FetchOptions } from './middleware.builders.js'
+import { fetchOne, fetchIf, fetchMany, renderTemplate, FetchOptions } from './middleware.builders.js'
 import { fetchResourceStatus } from './datasetTaskList.middleware.js'
 import performanceDbApi from '../services/performanceDbApi.js'
 
@@ -173,11 +173,9 @@ const getDatasetOverview = renderTemplate(
 export default [
   fetchOrgInfo,
   fetchDatasetInfo,
-  parallel([
-    fetchColumnSummary,
-    fetchResourceStatus,
-    fetchIf(isResourceIdInParams, fetchLatestResource, takeResourceIdFromParams)
-  ]),
+  fetchColumnSummary,
+  fetchResourceStatus,
+  fetchIf(isResourceIdInParams, fetchLatestResource, takeResourceIdFromParams),
   fetchIf(isResourceAccessible, fetchLpaDatasetIssues),
   fetchSpecification,
   pullOutDatasetSpecification,

--- a/src/middleware/datasetTaskList.middleware.js
+++ b/src/middleware/datasetTaskList.middleware.js
@@ -1,5 +1,5 @@
 import { fetchDatasetInfo, isResourceAccessible, isResourceNotAccessible, fetchLatestResource, fetchEntityCount, logPageError, fetchLpaDatasetIssues } from './common.middleware.js'
-import { parallel, fetchOne, fetchIf, onlyIf, renderTemplate } from './middleware.builders.js'
+import { fetchOne, fetchIf, onlyIf, renderTemplate } from './middleware.builders.js'
 import performanceDbApi from '../services/performanceDbApi.js'
 import { statusToTagClass } from '../filters/filters.js'
 
@@ -116,10 +116,8 @@ export default [
   fetchOrgInfoWithStatGeo,
   fetchDatasetInfo,
   fetchIf(isResourceAccessible, fetchLatestResource),
-  parallel([
-    fetchIf(isResourceAccessible, fetchLpaDatasetIssues),
-    fetchIf(isResourceAccessible, fetchEntityCount)
-  ]),
+  fetchIf(isResourceAccessible, fetchLpaDatasetIssues),
+  fetchIf(isResourceAccessible, fetchEntityCount),
   onlyIf(isResourceAccessible, prepareDatasetTaskListTemplateParams),
   onlyIf(isResourceAccessible, getDatasetTaskList),
 

--- a/src/middleware/issueDetails.middleware.js
+++ b/src/middleware/issueDetails.middleware.js
@@ -2,7 +2,7 @@ import performanceDbApi from '../services/performanceDbApi.js'
 import logger from '../utils/logger.js'
 import { types } from '../utils/logging.js'
 import { fetchDatasetInfo, fetchEntityCount, fetchLatestResource, fetchOrgInfo, isResourceIdInParams, logPageError, takeResourceIdFromParams, validateQueryParams } from './common.middleware.js'
-import { fetchIf, parallel, renderTemplate } from './middleware.builders.js'
+import { fetchIf, renderTemplate } from './middleware.builders.js'
 import * as v from 'valibot'
 import { pagination } from '../utils/pagination.js'
 
@@ -291,11 +291,9 @@ export default [
   fetchIf(isResourceIdInParams, fetchLatestResource, takeResourceIdFromParams),
   fetchIssues,
   reformatIssuesToBeByEntryNumber,
-  parallel([
-    fetchEntry,
-    fetchEntityCount,
-    fetchIssueEntitiesCount
-  ]),
+  fetchEntry,
+  fetchEntityCount,
+  fetchIssueEntitiesCount,
   prepareIssueDetailsTemplateParams,
   getIssueDetails,
   logPageError

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -21,6 +21,21 @@ export const dataSubjects = {
       }
     ]
   },
+  'brownfield-land': {
+    available: true,
+    dataSets: [
+      {
+        value: 'brownfield-land',
+        text: 'Brownfield land',
+        available: true
+      },
+      {
+        value: 'brownfield-site',
+        text: 'Brownfield site',
+        available: false
+      }
+    ]
+  },
   'conservation-area': {
     available: true,
     dataSets: [

--- a/src/views/organisations/dataset-overview.html
+++ b/src/views/organisations/dataset-overview.html
@@ -5,6 +5,7 @@
 
 {% set showMap = [
   "article-4-direction-area",
+  "brownfield-land",
   "conservation-area",
   "listed-building",
   "listed-building-outline",
@@ -75,9 +76,9 @@
       text: "Licence"
     },
     value: {
-      text: "Open Government Licence" 
+      text: "Open Government Licence"
     }
-  }  
+  }
 ] %}
 
 {% for endpoint in stats.endpoints %}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- Feature

## Description
Adds the brownfield land dataset to the submit service as options for the dashboard and check tool

## Related Tickets & Documents
- Closes #531 

## QA Instructions, Screenshots, Recordings
### Preview Link: https://submit-pr-535.herokuapp.com/

## Added/updated tests?
- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests