### PR TITLE
Account for status/exception -> latest_status/exception rename

### DIFF
--- a/src/middleware/datasetOverview.middleware.js
+++ b/src/middleware/datasetOverview.middleware.js
@@ -46,7 +46,7 @@ export const pullOutDatasetSpecification = (req, res, next) => {
 
 const fetchSources = fetchMany({
   query: ({ params }) => `
-    select rhe.endpoint, rhe.endpoint_url, rhe.latest_status as status, rhe.latest_exception as exception, rhe.resource, rhe.latest_log_entry_date, rhe.endpoint_entry_date, rhe.endpoint_end_date, rhe.resource_start_date, rhe.resource_end_date, s.documentation_url
+    select rhe.endpoint, rhe.endpoint_url, rhe.status, rhe.exception, rhe.resource, rhe.latest_log_entry_date, rhe.endpoint_entry_date, rhe.endpoint_end_date, rhe.resource_start_date, rhe.resource_end_date, s.documentation_url
     from reporting_historic_endpoints rhe
     LEFT JOIN source s ON rhe.endpoint = s.endpoint
     where REPLACE(rhe.organisation, '-eng', '') = '${params.lpa}' and rhe.pipeline = '${params.dataset}'

--- a/src/middleware/datasetOverview.middleware.js
+++ b/src/middleware/datasetOverview.middleware.js
@@ -46,7 +46,7 @@ export const pullOutDatasetSpecification = (req, res, next) => {
 
 const fetchSources = fetchMany({
   query: ({ params }) => `
-    select rhe.endpoint, rhe.endpoint_url, rhe.latest_status as status, rhe.latest_exception as status, rhe.resource, rhe.latest_log_entry_date, rhe.endpoint_entry_date, rhe.endpoint_end_date, rhe.resource_start_date, rhe.resource_end_date, s.documentation_url
+    select rhe.endpoint, rhe.endpoint_url, rhe.latest_status as status, rhe.latest_exception as exception, rhe.resource, rhe.latest_log_entry_date, rhe.endpoint_entry_date, rhe.endpoint_end_date, rhe.resource_start_date, rhe.resource_end_date, s.documentation_url
     from reporting_historic_endpoints rhe
     LEFT JOIN source s ON rhe.endpoint = s.endpoint
     where REPLACE(rhe.organisation, '-eng', '') = '${params.lpa}' and rhe.pipeline = '${params.dataset}'

--- a/src/middleware/datasetOverview.middleware.js
+++ b/src/middleware/datasetOverview.middleware.js
@@ -46,7 +46,7 @@ export const pullOutDatasetSpecification = (req, res, next) => {
 
 const fetchSources = fetchMany({
   query: ({ params }) => `
-    select rhe.endpoint, rhe.endpoint_url, rhe.status, rhe.exception, rhe.resource, rhe.latest_log_entry_date, rhe.endpoint_entry_date, rhe.endpoint_end_date, rhe.resource_start_date, rhe.resource_end_date, s.documentation_url
+    select rhe.endpoint, rhe.endpoint_url, rhe.latest_status as status, rhe.latest_exception as status, rhe.resource, rhe.latest_log_entry_date, rhe.endpoint_entry_date, rhe.endpoint_end_date, rhe.resource_start_date, rhe.resource_end_date, s.documentation_url
     from reporting_historic_endpoints rhe
     LEFT JOIN source s ON rhe.endpoint = s.endpoint
     where REPLACE(rhe.organisation, '-eng', '') = '${params.lpa}' and rhe.pipeline = '${params.dataset}'


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The status and exception columns in the reporting_historic/latest_endpoints tables are being renamed to latest_status and latest_exception. This PR accounts for that change

## Related Tickets & Documents

https://trello.com/c/NJSZQBUZ/3512-perf-db-general-changes

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [X] No, and this is why: Refactor
- [ ] I need help with writing tests

## [optional] Are there any dependencies on other PRs or Work?
Should not be merged until the updated tables have been deployed from [this PR](https://github.com/digital-land/digital-land-builder/pull/36)