### PR TITLE
Check Tool: Deep links support 

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -21,7 +21,7 @@ serviceName: 'Submit and update your planning data'
 # NOTE: the keys in this map are sometimes referred to as "serviceType" in the templates
 serviceNames: {
     submit: 'Submit and update your planning data',
-    check: 'Check planning and housing data for England',
+    check: 'Submit and update your planning data',
     manage: 'Submit and update your planning data'
 }
 checkService:

--- a/src/controllers/chooseDatasetController.js
+++ b/src/controllers/chooseDatasetController.js
@@ -1,16 +1,10 @@
 import PageController from './pageController.js'
 
-import { dataSubjects } from '../utils/utils.js'
+import { dataSubjects, availableDatasets } from '../utils/utils.js'
 
 class ChooseDatasetController extends PageController {
   locals (req, res, next) {
-    const availableDataSubjects = Object.values(dataSubjects).filter(dataSubject => dataSubject.available)
-    const dataSets = Object.values(availableDataSubjects).map(dataSubject => dataSubject.dataSets).flat()
-    const availableDatasets = dataSets.filter(dataSet => dataSet.available)
-    availableDatasets.sort((a, b) => a.text.localeCompare(b.text))
-
-    req.form.options.datasetItems = availableDatasets
-
+    req.form.options.datasetItems = availableDatasets(dataSubjects)
     super.locals(req, res, next)
   }
 }

--- a/src/controllers/datasetController.js
+++ b/src/controllers/datasetController.js
@@ -4,45 +4,30 @@ import PageController from './pageController.js'
 
 // ToDo: we shouldn't hardcode these values here, should we get them from the API
 //  maybe take from specification
-import { dataSubjects } from '../utils/utils.js'
+import { dataSubjects, datasets, availableDatasets } from '../utils/utils.js'
+
+/**
+ * @param req
+ * @returns {boolean}
+ */
+export function requiresGeometryTypeToBeSelected (req) {
+  const dataset = req.body.dataset
+  const dataSet = datasets.get(dataset)
+  return dataSet?.requiresGeometryTypeSelection || false
+}
 
 class DatasetController extends PageController {
   locals (req, res, next) {
-    const availableDataSubjects = Object.values(dataSubjects).filter(dataSubject => dataSubject.available)
-    const dataSets = Object.values(availableDataSubjects).map(dataSubject => dataSubject.dataSets).flat()
-    const availableDatasets = dataSets.filter(dataSet => dataSet.available)
-    availableDatasets.sort((a, b) => a.text.localeCompare(b.text))
-
-    req.form.options.datasetItems = availableDatasets
-
+    req.form.options.datasetItems = availableDatasets(dataSubjects)
     super.locals(req, res, next)
   }
 
   // we shouldn't need this here but as we dont currently set the datasubject, we need to do so here
   post (req, res, next) {
     const dataset = req.body.dataset
-    // set the data-subject based on the dataset selected
-    let dataSubject = ''
-    for (const [key, value] of Object.entries(dataSubjects)) {
-      if (value.dataSets.find(dataSet => dataSet.value === dataset)) {
-        dataSubject = key
-        break
-      }
-    }
+    const { dataSubject } = datasets.get(dataset) || { dataSubject: '' }
     req.body['data-subject'] = dataSubject
     super.post(req, res, next)
-  }
-
-  requiresGeometryTypeToBeSelected (req) {
-    const dataset = req.body.dataset
-
-    if (!dataset) {
-      return false
-    }
-
-    const dataSubject = Object.values(dataSubjects).find(dataSubject => dataSubject.dataSets.find(dataSet => dataSet.value === dataset))
-    const dataSet = dataSubject.dataSets.find(dataSet => dataSet.value === dataset)
-    return dataSet.requiresGeometryTypeSelection || false
   }
 }
 

--- a/src/controllers/datasetController.js
+++ b/src/controllers/datasetController.js
@@ -7,11 +7,21 @@ import PageController from './pageController.js'
 import { dataSubjects, datasets, availableDatasets } from '../utils/utils.js'
 
 /**
- * @param req
+ * @param {Object} req
  * @returns {boolean}
  */
 export function requiresGeometryTypeToBeSelected (req) {
   const dataset = req.body.dataset
+  const dataSet = datasets.get(dataset)
+  return dataSet?.requiresGeometryTypeSelection || false
+}
+
+/**
+ * @param {Object} req - The HTTP request object.
+ * @returns {boolean}
+ */
+export function requiresGeometryTypeToBeSelectedViaDeepLink (req) {
+  const { dataset } = req.query
   const dataSet = datasets.get(dataset)
   return dataSet?.requiresGeometryTypeSelection || false
 }

--- a/src/controllers/deepLinkController.js
+++ b/src/controllers/deepLinkController.js
@@ -1,0 +1,59 @@
+import PageController from './pageController.js'
+
+import { datasets } from '../utils/utils.js'
+import logger from '../utils/logger.js'
+import { types } from '../utils/logging.js'
+import * as v from 'valibot'
+import { NonEmptyString } from '../routes/schemas.js'
+
+const QueryParams = v.object({
+  dataset: NonEmptyString,
+  orgName: NonEmptyString
+})
+
+/**
+ * Handles deep links in the Check Tool.
+ *
+ * It is meant to extract required params from query params
+ * and partially pre-populate the session with them,
+ * then redirect the user to the "next" page in the wizard
+ */
+class DeepLinkController extends PageController {
+  get (req, res, next) {
+    // if the query params don't contain what we need, redirect to the "get started" page,
+    // this way the user can still proceed (but need to fill the dataset+orgName themselves)
+    const { dataset, orgName } = req.query
+    const validationResult = v.safeParse(QueryParams, req.query)
+    if (!(validationResult.success && datasets.has(dataset))) {
+      logger.info('DeepLinkController.get(): invalid params for deep link, redirecting to start page',
+        { type: types.App, query: req.query })
+      return res.redirect('/check')
+    }
+
+    req.sessionModel.set('dataset', dataset)
+    const datasetInfo = datasets.get(dataset) ?? { dataSubject: '', requiresGeometryTypeSelection: false }
+    req.sessionModel.set('data-subject', datasetInfo.dataSubject)
+    req.sessionModel.set(this.checkToolDeepLinkSessionKey,
+      { 'data-subject': datasetInfo.dataSubject, orgName, dataset, datasetName: datasetInfo.text })
+
+    this.#addHistoryStep(req, '/check/dataset')
+
+    super.post(req, res, next)
+  }
+
+  #addHistoryStep (req, path, next) {
+    const newItem = {
+      path,
+      wizard: 'check-wizard',
+      fields: ['dataset', 'data-subject'],
+      skip: false,
+      continueOnEdit: false
+    }
+
+    const history = req.journeyModel.get('history') || []
+    history.push(newItem)
+    req.journeyModel.set('history', history)
+  }
+}
+
+export default DeepLinkController

--- a/src/controllers/pageController.js
+++ b/src/controllers/pageController.js
@@ -3,14 +3,21 @@ import { logPageView } from '../utils/logging.js'
 const { Controller } = hmpoFormWizard
 
 class PageController extends Controller {
-  configure (req, res, callback) {
-    req.form.options.lastPage = this.options.backLink ? this.options.backLink : undefined
-    super.configure(req, res, callback)
-  }
+  checkToolDeepLinkSessionKey = 'check-tool-deep-link'
 
   get (req, res, next) {
     logPageView(this.options.route, req.sessionID, req.ip)
     super.get(req, res, next)
+  }
+
+  locals (req, res, next) {
+    if (this.options.backLink) {
+      req.form.options.lastPage = this.options.backLink
+    }
+    if (req.sessionModel) {
+      req.form.options.deepLink = req.sessionModel.get(this.checkToolDeepLinkSessionKey)
+    }
+    super.locals(req, res, next)
   }
 }
 

--- a/src/controllers/uploadFileController.js
+++ b/src/controllers/uploadFileController.js
@@ -64,7 +64,7 @@ class UploadFileController extends UploadController {
 
       logger.info('UploadFileController: file submitted for processing:', { type: 'fileUploaded', name: req.file.originalname, mimetype: req.file.mimetype, size: req.file.size })
 
-      super.post(req, res, next)
+      await super.post(req, res, next)
     } catch (error) {
       next(error)
     }

--- a/src/filters/checkToolDeepLink.js
+++ b/src/filters/checkToolDeepLink.js
@@ -1,0 +1,11 @@
+/**
+ * Returns the deep link to the check tool for a given dataset and organisation
+ *
+ * @param {{name:string}} organisation
+ * @param {{dataset:string, name:string}} dataset
+ *
+ * @return {string}
+ */
+export function checkToolDeepLink (organisation, dataset) {
+  return `/check/link?dataset=${encodeURIComponent(dataset.dataset)}&orgName=${encodeURIComponent(organisation.name)}`
+}

--- a/src/filters/filters.js
+++ b/src/filters/filters.js
@@ -5,6 +5,7 @@ import toErrorList from './toErrorList.js'
 import prettifyColumnName from './prettifyColumnName.js'
 import getFullServiceName from './getFullServiceName.js'
 import { makeDatasetSlugToReadableNameFilter } from './makeDatasetSlugToReadableNameFilter.js'
+import { checkToolDeepLink } from './checkToolDeepLink.js'
 import pluralize from 'pluralize'
 
 /** maps dataset status (as returned by `fetchLpaOverview` middleware to a
@@ -40,6 +41,7 @@ const addFilters = (nunjucksEnv, { datasetNameMapping }) => {
   nunjucksEnv.addFilter('getFullServiceName', getFullServiceName)
   nunjucksEnv.addFilter('statusToTagClass', statusToTagClass)
   nunjucksEnv.addFilter('pluralise', pluralize)
+  nunjucksEnv.addFilter('checkToolDeepLink', checkToolDeepLink)
 }
 
 export default addFilters

--- a/src/middleware/common.middleware.js
+++ b/src/middleware/common.middleware.js
@@ -79,13 +79,17 @@ export const fetchOrgInfo = fetchOne({
  * @param {*} res
  * @param {*} next
  */
-export function validateQueryParams (req, res, next) {
+export function validateQueryParamsFn (req, res, next) {
   try {
     v.parse(this.schema || v.any(), req.params)
     next()
   } catch (error) {
     res.status(400).render('errorPages/400', {})
   }
+}
+
+export function validateQueryParams (context) {
+  return validateQueryParamsFn.bind(context)
 }
 
 export const fetchLpaDatasetIssues = fetchMany({

--- a/src/middleware/datasetTaskList.middleware.js
+++ b/src/middleware/datasetTaskList.middleware.js
@@ -1,7 +1,8 @@
-import { fetchDatasetInfo, isResourceAccessible, isResourceNotAccessible, fetchLatestResource, fetchEntityCount, logPageError, fetchLpaDatasetIssues } from './common.middleware.js'
+import { fetchDatasetInfo, isResourceAccessible, isResourceNotAccessible, fetchLatestResource, fetchEntityCount, logPageError, fetchLpaDatasetIssues, validateQueryParams } from './common.middleware.js'
 import { fetchOne, fetchIf, onlyIf, renderTemplate } from './middleware.builders.js'
 import performanceDbApi from '../services/performanceDbApi.js'
 import { statusToTagClass } from '../filters/filters.js'
+import * as v from 'valibot'
 
 /**
  * Fetches the resource status
@@ -111,7 +112,15 @@ const getDatasetTaskListError = renderTemplate({
   handlerName: 'getDatasetTaskListError'
 })
 
+const validateParams = validateQueryParams({
+  schema: v.object({
+    lpa: v.string(),
+    dataset: v.string()
+  })
+})
+
 export default [
+  validateParams,
   fetchResourceStatus,
   fetchOrgInfoWithStatGeo,
   fetchDatasetInfo,

--- a/src/middleware/issueDetails.middleware.js
+++ b/src/middleware/issueDetails.middleware.js
@@ -15,7 +15,7 @@ export const IssueDetailsQueryParams = v.object({
   resourceId: v.optional(v.string())
 })
 
-const validateIssueDetailsQueryParams = validateQueryParams.bind({
+const validateIssueDetailsQueryParams = validateQueryParams({
   schema: IssueDetailsQueryParams
 })
 

--- a/src/middleware/overview.middleware.js
+++ b/src/middleware/overview.middleware.js
@@ -56,7 +56,7 @@ const fetchEntityCounts = async (req, res, next) => {
 const statusOrdering = new Map(['Live', 'Needs fixing', 'Error', 'Not submitted'].map((status, i) => [status, i]))
 
 /**
- * The overview data can contain multiple rows per dataset
+ * The overview data can contain multiple rows per dataset,
  * and we want a collection of with one item per dataset,
  * because that's how we display it on the page.
  *
@@ -94,7 +94,7 @@ export function aggregateOverviewData (lpaOverview) {
 }
 
 /**
- * Calculates overal "health" of the datasets (not)provided by an organisation.
+ * Calculates overall "health" of the datasets (not)provided by an organisation.
  *
  * @param {[number, number, number]} accumulator
  * @param {{ endpoint?: string, status: string }} dataset

--- a/src/routes/form-wizard/check/steps.js
+++ b/src/routes/form-wizard/check/steps.js
@@ -1,6 +1,9 @@
 // ToDo: Split this into two form wizards
 import PageController from '../../../controllers/pageController.js'
-import datasetController, { requiresGeometryTypeToBeSelected } from '../../../controllers/datasetController.js'
+import datasetController, {
+  requiresGeometryTypeToBeSelected,
+  requiresGeometryTypeToBeSelectedViaDeepLink
+} from '../../../controllers/datasetController.js'
 import uploadFileController from '../../../controllers/uploadFileController.js'
 import submitUrlController from '../../../controllers/submitUrlController.js'
 import statusController from '../../../controllers/statusController.js'
@@ -100,7 +103,7 @@ export default {
     ...baseSettings,
     controller: deepLinkController,
     next: [
-      { field: 'dataset', fn: requiresGeometryTypeToBeSelected, next: 'geometry-type' },
+      { field: 'dataset', fn: requiresGeometryTypeToBeSelectedViaDeepLink, next: 'geometry-type' },
       'upload-method'
     ],
     entryPoint: true,

--- a/src/routes/schemas.js
+++ b/src/routes/schemas.js
@@ -14,7 +14,7 @@ export const ErrorParams = v.strictObject({
   err: v.object({})
 })
 
-const NonEmptyString = v.pipe(v.string(), v.nonEmpty())
+export const NonEmptyString = v.pipe(v.string(), v.nonEmpty())
 
 export const Base = v.object({
   // serviceName: NonEmptyString,

--- a/src/serverSetup/session.js
+++ b/src/serverSetup/session.js
@@ -1,13 +1,11 @@
 import session from 'express-session'
 import { createClient } from 'redis'
 import RedisStore from 'connect-redis'
-import cookieParser from 'cookie-parser'
 import config from '../../config/index.js'
 import logger from '../utils/logger.js'
 import { types } from '../utils/logging.js'
 
 export async function setupSession (app) {
-  app.use(cookieParser())
   let sessionStore
   if ('redis' in config) {
     const urlPrefix = `redis${config.redis.secure ? 's' : ''}`

--- a/src/services/asyncRequestApi.js
+++ b/src/services/asyncRequestApi.js
@@ -45,8 +45,9 @@ const postRequest = async (formData) => {
     const errorMessage = `post request failed: response.status = '${error.response?.status}', ` +
       `data: '${error.response?.data}', ` +
       `cause: '${error?.cause}' ` +
+      `code: ${error.code}, ` +
       (error.request ? 'No response received, ' : '') +
-      `message: '${error.message ?? 'no meesage provided'}', ` +
+      `message: '${error.message ?? 'no message provided'}', ` +
       (error.config ? `Error in Axios configuration ${error?.config}` : '')
 
     throw new Error(errorMessage)

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -94,6 +94,35 @@ export const dataSubjects = {
   }
 }
 
+export function makeDatasetsLookup (dataSubjects) {
+  const lookup = new Map()
+  for (const [key, dataSubject] of Object.entries(dataSubjects)) {
+    for (const dataSet of dataSubject.dataSets) {
+      lookup.set(dataSet.value, { ...dataSet, dataSubject: key })
+    }
+  }
+
+  return lookup
+}
+
+/**
+ * @type {Map<string, {value: string, text: string, available: boolean, dataSubject: string, requiresGeometryTypeSelection?: boolean}>}
+ */
+export const datasets = makeDatasetsLookup(dataSubjects)
+
+/**
+ *
+ * @param dataSubjects
+ * @returns {FlatArray<*[], 1>[]} datasets sorted by 'text' property
+ */
+export function availableDatasets (dataSubjects) {
+  const availableDataSubjects = Object.values(dataSubjects).filter(dataSubject => dataSubject.available)
+  const dataSets = Object.values(availableDataSubjects).map(dataSubject => dataSubject.dataSets).flat()
+  const availableDatasets = dataSets.filter(dataSet => dataSet.available)
+  availableDatasets.sort((a, b) => a.text.localeCompare(b.text))
+  return availableDatasets
+}
+
 export const finishedProcessingStatuses = [
   'COMPLETE',
   'FAILED'

--- a/src/views/check/geometry-type.html
+++ b/src/views/check/geometry-type.html
@@ -2,6 +2,7 @@
 {% from 'govuk/components/radios/macro.njk' import govukRadios %}
 {% from 'govuk/components/error-message/macro.njk' import govukErrorMessage %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
+{% from 'components/dataset-banner.html' import datasetBanner %}
 
 {% extends "layouts/main.html" %}
 
@@ -23,6 +24,11 @@
 {% endblock %}
 
 {% block content %}
+
+  {% if options.deepLink %}
+   {{ datasetBanner(options.deepLink) }}
+  {% endif %}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% if error %}

--- a/src/views/check/geometry-type.html
+++ b/src/views/check/geometry-type.html
@@ -25,10 +25,6 @@
 
 {% block content %}
 
-  {% if options.deepLink %}
-   {{ datasetBanner(options.deepLink) }}
-  {% endif %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% if error %}
@@ -43,6 +39,10 @@
         }) }}
       {% endif %}
       <form novalidate method="post">
+
+        {% if options.deepLink %}
+          {{ datasetBanner(options.deepLink) }}
+        {% endif %}
 
         {{ govukRadios({
           name: "geomType",

--- a/src/views/check/results/errors.html
+++ b/src/views/check/results/errors.html
@@ -4,7 +4,6 @@
 {% from 'govuk/components/radios/macro.njk' import govukRadios %}
 {% from 'govuk/components/inset-text/macro.njk' import govukInsetText %}
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
-
 {% from "../../components/table.html" import table %}
 
 {% set serviceType = 'Check' %}
@@ -21,6 +20,7 @@
 {% endblock %}
 
 {% block content %}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l">

--- a/src/views/check/results/errors.html
+++ b/src/views/check/results/errors.html
@@ -5,6 +5,7 @@
 {% from 'govuk/components/inset-text/macro.njk' import govukInsetText %}
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 {% from "../../components/table.html" import table %}
+{% from '../../components/dataset-banner.html' import datasetBanner %}
 
 {% set serviceType = 'Check' %}
 {% set pageName = 'Your data has errors' %}

--- a/src/views/check/results/errors.html
+++ b/src/views/check/results/errors.html
@@ -23,9 +23,13 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-l">
-        {{options.requestParams.dataset}}
-      </span>
+
+      {% if options.deepLink %}
+        {{ datasetBanner(options.deepLink) }}
+      {% else %}
+        <span class="govuk-caption-l">{{options.requestParams.dataset}}</span>
+      {% endif %}
+
       <h1 class="govuk-heading-l">
         {{pageName}}
       </h1>

--- a/src/views/check/results/no-errors.html
+++ b/src/views/check/results/no-errors.html
@@ -4,7 +4,7 @@
 {% from 'govuk/components/radios/macro.njk' import govukRadios %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
-
+{% from '../../components/dataset-banner.html' import datasetBanner %}
 {% from "../../components/table.html" import table %}
 
 
@@ -33,6 +33,11 @@
 
 
 {% block content %}
+
+  {% if options.deepLink %}
+    {{ datasetBanner(options.deepLink) }}
+  {% endif %}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">

--- a/src/views/check/results/no-errors.html
+++ b/src/views/check/results/no-errors.html
@@ -34,12 +34,11 @@
 
 {% block content %}
 
-  {% if options.deepLink %}
-    {{ datasetBanner(options.deepLink) }}
-  {% endif %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {% if options.deepLink %}
+        {{ datasetBanner(options.deepLink) }}
+      {% endif %}
       <h1 class="govuk-heading-l">
         {{pageName}}
       </h1>

--- a/src/views/check/statusPage/status.html
+++ b/src/views/check/statusPage/status.html
@@ -1,7 +1,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "./checkingFileMacro.html" import checkingFileContent %}
 {% from "./fileCheckedMacro.html" import fileCheckedContent %}
-{% from 'components/dataset-banner.html' import datasetBanner %}
+{% from '../../components/dataset-banner.html' import datasetBanner %}
 
 {% extends "layouts/main.html" %}
 

--- a/src/views/check/statusPage/status.html
+++ b/src/views/check/statusPage/status.html
@@ -1,6 +1,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "./checkingFileMacro.html" import checkingFileContent %}
 {% from "./fileCheckedMacro.html" import fileCheckedContent %}
+{% from 'components/dataset-banner.html' import datasetBanner %}
 
 {% extends "layouts/main.html" %}
 
@@ -20,6 +21,9 @@
 {% block content %}
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds" aria-live="assertive">
+      {% if options.deepLink %}
+        {{ datasetBanner(options.deepLink) }}
+      {% endif %}
       {{ pageContent }}
     </div>
 

--- a/src/views/check/upload-method.html
+++ b/src/views/check/upload-method.html
@@ -25,11 +25,6 @@
 
 {% block content %}
 
-  {% if options.deepLink %}
-    {{ datasetBanner(options.deepLink) }}
-  {% endif %}
-
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% if error %}
@@ -44,6 +39,10 @@
         }) }}
       {% endif %}
       <form novalidate method="post">
+
+        {% if options.deepLink %}
+          {{ datasetBanner(options.deepLink) }}
+        {% endif %}
 
         {{ govukRadios({
           name: "upload-method",

--- a/src/views/check/upload-method.html
+++ b/src/views/check/upload-method.html
@@ -2,6 +2,7 @@
 {% from 'govuk/components/radios/macro.njk' import govukRadios %}
 {% from 'govuk/components/error-message/macro.njk' import govukErrorMessage %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
+{% from 'components/dataset-banner.html' import datasetBanner %}
 
 {% extends "layouts/main.html" %}
 
@@ -23,6 +24,12 @@
 {% endblock %}
 
 {% block content %}
+
+  {% if options.deepLink %}
+    {{ datasetBanner(options.deepLink) }}
+  {% endif %}
+
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% if error %}

--- a/src/views/check/upload.html
+++ b/src/views/check/upload.html
@@ -32,11 +32,6 @@
 
 {% block content %}
 
-  {% if options.deepLink %}
-    {{ datasetBanner(options.deepLink) }}
-  {% endif %}
-
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% if error %}
@@ -51,6 +46,10 @@
         }) }}
       {% endif %}
       <form novalidate method="post" enctype="multipart/form-data">
+
+        {% if options.deepLink %}
+          {{ datasetBanner(options.deepLink) }}
+        {% endif %}
 
         {{ govukFileUpload({
           id: "datafile",

--- a/src/views/check/upload.html
+++ b/src/views/check/upload.html
@@ -4,6 +4,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from 'govuk/components/error-message/macro.njk' import govukErrorMessage %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
+{% from 'components/dataset-banner.html' import datasetBanner %}
 
 {% set serviceType = 'Check' %}
 {% set pageName = 'Upload data' %}
@@ -30,6 +31,12 @@
 {% endblock %}
 
 {% block content %}
+
+  {% if options.deepLink %}
+    {{ datasetBanner(options.deepLink) }}
+  {% endif %}
+
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% if error %}

--- a/src/views/check/url.html
+++ b/src/views/check/url.html
@@ -34,11 +34,8 @@
 
 {% block content %}
 
-  {% if options.deepLink %}
-      {{ datasetBanner(options.deepLink) }}
-  {% endif %}
-
   <div class="govuk-grid-row">
+
     <div class="govuk-grid-column-two-thirds">
       {% if error %}
         {{ govukErrorSummary({
@@ -52,7 +49,9 @@
         }) }}
       {% endif %}
       <form novalidate method="post">
-
+        {% if options.deepLink %}
+          {{ datasetBanner(options.deepLink) }}
+        {% endif %}
         {{ govukInput({
           id: "url",
           name: "url",

--- a/src/views/check/url.html
+++ b/src/views/check/url.html
@@ -4,6 +4,7 @@
 {% from 'govuk/components/input/macro.njk' import govukInput %}
 {% from 'govuk/components/error-message/macro.njk' import govukErrorMessage %}
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
+{% from 'components/dataset-banner.html' import datasetBanner %}
 
 {% set serviceType = 'Check' %}
 {% set pageName = 'URL' %}
@@ -32,6 +33,11 @@
 {% endblock %}
 
 {% block content %}
+
+  {% if options.deepLink %}
+      {{ datasetBanner(options.deepLink) }}
+  {% endif %}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% if error %}

--- a/src/views/components/dataset-banner.html
+++ b/src/views/components/dataset-banner.html
@@ -1,0 +1,8 @@
+{% macro datasetBanner(params) %}
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <span class="govuk-caption-xl">{{ params.orgName }}</span>
+        <h1 class="govuk-heading-xl">{{ params.datasetName }}</h1>
+    </div>
+</div>
+{% endmacro %}

--- a/src/views/components/dataset-banner.html
+++ b/src/views/components/dataset-banner.html
@@ -1,8 +1,3 @@
 {% macro datasetBanner(params) %}
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        <span class="govuk-caption-xl">{{ params.orgName }}</span>
-        <h1 class="govuk-heading-xl">{{ params.datasetName }}</h1>
-    </div>
-</div>
+<span class="govuk-caption-xl">{{ params.datasetName }}</span>
 {% endmacro %}

--- a/src/views/errorPages/500.html
+++ b/src/views/errorPages/500.html
@@ -10,6 +10,9 @@
       <p>
         You'll need to <a href="/">start from the beginning of the service</a>.
       </p>
+      <div style="display:none">
+        {{ err.message }}
+      </div>
     </div>
   </div>
 {% endblock %}

--- a/src/views/errorPages/500.html
+++ b/src/views/errorPages/500.html
@@ -10,9 +10,6 @@
       <p>
         You'll need to <a href="/">start from the beginning of the service</a>.
       </p>
-      <div style="display:none">
-        {{ err.message }}
-      </div>
     </div>
   </div>
 {% endblock %}

--- a/src/views/organisations/datasetTaskList.html
+++ b/src/views/organisations/datasetTaskList.html
@@ -77,7 +77,7 @@
 
     <ol class="govuk-list govuk-list--number">
       <li>Fix the errors indicated</li>
-      <li>Use the <a href="/check">check service</a> to make sure the data meets
+      <li>Use the <a href="{{ organisation | checkToolDeepLink(dataset) }}">check service</a> to make sure the data meets
         the standard</li>
       <li>Publish the updated data on the data URL</li>
     </ol>

--- a/src/views/organisations/get-started.html
+++ b/src/views/organisations/get-started.html
@@ -100,7 +100,7 @@
             <ol class="gem-c-step-nav__list " data-length="1">
               <li class="gem-c-step-nav__list-item js-list-item ">
                 <p class="gem-c-step-nav__paragraph">
-                  The <a href="/check">check service</a> can help you understand
+                  The <a href="{{ organisation | checkToolDeepLink(dataset) }}">check service</a> can help you understand
                   if
                   your data is ready to submit or if you need to change anything before you publish it on your website.
                 </p>
@@ -120,7 +120,7 @@
                 <ol class="gem-c-step-nav__list " data-length="1">
                   <li class="gem-c-step-nav__list-item js-list-item ">
                     <a data-position="2.1" class="gem-c-step-nav__link js-link"
-                      href="/check">Check your data</a>
+                      href="{{ organisation | checkToolDeepLink(dataset) }}">Check your data</a>
                   </li>
                 </ol>
               </li>

--- a/src/views/organisations/issueDetails.html
+++ b/src/views/organisations/issueDetails.html
@@ -4,7 +4,6 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
-{% from 'components/dataset-banner.html' import datasetBanner %}
 
 {% set serviceType = 'Submit'%}
 
@@ -45,10 +44,6 @@
 {% endblock %}
 
 {% block content %}
-
-{% if options.deepLink %}
-  {{ datasetBanner(options.deepLink) }}
-{% endif %}
 
 <div class="govuk-grid-row">
   {% include "includes/_dataset-page-header.html" %}

--- a/src/views/organisations/issueDetails.html
+++ b/src/views/organisations/issueDetails.html
@@ -4,6 +4,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from 'components/dataset-banner.html' import datasetBanner %}
 
 {% set serviceType = 'Submit'%}
 
@@ -45,6 +46,9 @@
 
 {% block content %}
 
+{% if options.deepLink %}
+  {{ datasetBanner(options.deepLink) }}
+{% endif %}
 
 <div class="govuk-grid-row">
   {% include "includes/_dataset-page-header.html" %}

--- a/test/unit/check-answers.test.js
+++ b/test/unit/check-answers.test.js
@@ -21,7 +21,7 @@ describe('check-answers View', async () => {
   const html = stripWhitespace(nunjucks.render('check-answers.html', params))
 
   runGenericPageTests(html, {
-    pageTitle: 'Check your answers - Check planning and housing data for England'
+    pageTitle: 'Check your answers - Submit and update your planning data'
   })
 
   it('should render the lpa selected', () => {

--- a/test/unit/chooseDatasetController.test.js
+++ b/test/unit/chooseDatasetController.test.js
@@ -10,13 +10,15 @@ describe('ChooseDatasetController', () => {
       route: '/dataset'
     })
 
-    vi.mock('../../src/utils/utils.js', () => {
+    vi.mock(import('../../src/utils/utils.js'), async (importOriginal) => {
+      const { availableDatasets } = await importOriginal()
       return {
         dataSubjects: {
           subject1: { available: true, dataSets: [{ available: true, text: 'B', value: 'B', requiresGeometryTypeSelection: true }, { available: false, text: 'A', value: 'A', requiresGeometryTypeSelection: false }] },
           subject2: { available: false, dataSets: [{ available: true, text: 'C', value: 'C', requiresGeometryTypeSelection: false }] },
           subject3: { available: true, dataSets: [{ available: true, text: 'A', value: 'A', requiresGeometryTypeSelection: true }] }
-        }
+        },
+        availableDatasets
       }
     })
   })

--- a/test/unit/datasetController.test.js
+++ b/test/unit/datasetController.test.js
@@ -1,4 +1,7 @@
-import DatasetController, { requiresGeometryTypeToBeSelected } from '../../src/controllers/datasetController.js'
+import DatasetController, {
+  requiresGeometryTypeToBeSelected,
+  requiresGeometryTypeToBeSelectedViaDeepLink
+} from '../../src/controllers/datasetController.js'
 import { describe, it, vi, expect, beforeEach } from 'vitest'
 
 describe('DatasetController', () => {
@@ -75,5 +78,19 @@ describe('DatasetController', () => {
     // Mock req with no dataset
     const req3 = { body: {} }
     expect(requiresGeometryTypeToBeSelected(req3)).toEqual(false)
+  })
+
+  it('Correctly determines whether a geometry type selection is required via deep link', () => {
+    // Mock req with dataset that requires geometry type selection
+    const req1 = { query: { dataset: 'B' } }
+    expect(requiresGeometryTypeToBeSelectedViaDeepLink(req1)).toEqual(true)
+
+    // Mock req with dataset that does not require geometry type selection
+    const req2 = { query: { dataset: 'D' } }
+    expect(requiresGeometryTypeToBeSelectedViaDeepLink(req2)).toEqual(false)
+
+    // Mock req with no dataset
+    const req3 = { query: {} }
+    expect(requiresGeometryTypeToBeSelectedViaDeepLink(req3)).toEqual(false)
   })
 })

--- a/test/unit/deepLinkController.test.js
+++ b/test/unit/deepLinkController.test.js
@@ -1,0 +1,53 @@
+import { describe, it, vi, expect, beforeEach } from 'vitest'
+import DeepLinkController from '../../src/controllers/deepLinkController.js'
+
+function mockRequestObject () {
+  const sessionModel = new Map()
+  const journeyModel = new Map()
+  return { sessionModel, journeyModel, query: {} }
+}
+
+function mockMiddlewareArgs (reqOpts) {
+  return {
+    req: { ...mockRequestObject(), ...reqOpts },
+    res: { redirect: vi.fn() },
+    next: vi.fn()
+  }
+}
+
+describe('DeepLinkController', () => {
+  let deepLinkController
+
+  beforeEach(() => {
+    deepLinkController = new DeepLinkController({
+      route: '/deep-link'
+    })
+  })
+
+  describe('get()', () => {
+    it('should redirect to check tool start page when params invalid', async () => {
+      const { req, res, next } = mockMiddlewareArgs({ query: {} })
+      deepLinkController.get(req, res, next)
+
+      expect(res.redirect).toHaveBeenCalledWith('/check')
+      expect(Array.from(req.sessionModel.keys())).toStrictEqual([])
+      expect(next).toBeCalledTimes(0)
+    })
+
+    it('should update session with deep link info', async () => {
+      const query = { dataset: 'conservation-area', orgName: 'Some Org' }
+      const { req, res, next } = mockMiddlewareArgs({ query })
+
+      deepLinkController.get(req, res, next)
+
+      expect(req.sessionModel.get(deepLinkController.checkToolDeepLinkSessionKey)).toStrictEqual({
+        'data-subject': 'conservation-area',
+        orgName: 'Some Org',
+        dataset: 'conservation-area',
+        datasetName: 'Conservation area dataset'
+      })
+      expect(req.journeyModel.get('history').length).toBe(1)
+      expect(next).toBeCalledTimes(1)
+    })
+  })
+})

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -1,0 +1,33 @@
+import * as util from '../../src/utils/utils.js'
+import { describe, it, expect } from 'vitest'
+
+const dataSubjects = {
+  subject1: {
+    available: true,
+    dataSets:
+      [{ available: true, text: 'B', value: 'B', requiresGeometryTypeSelection: true },
+        { available: false, text: 'D', value: 'D' }]
+  },
+  subject2: { available: false, dataSets: [{ available: true, text: 'C', value: 'C', requiresGeometryTypeSelection: false }] },
+  subject3: { available: true, dataSets: [{ available: true, text: 'A', value: 'A', requiresGeometryTypeSelection: true }] }
+}
+
+describe('utils/utils', () => {
+  it('makeDatasetsLookup()', () => {
+    const lookup = util.makeDatasetsLookup(dataSubjects)
+
+    expect(lookup.get('A')).toEqual({ ...dataSubjects.subject3.dataSets[0], dataSubject: 'subject3' })
+    expect(lookup.get('B')).toEqual({ ...dataSubjects.subject1.dataSets[0], dataSubject: 'subject1' })
+    expect(lookup.get('C')).toEqual({ ...dataSubjects.subject2.dataSets[0], dataSubject: 'subject2' })
+    expect(lookup.get('D')).toEqual({ ...dataSubjects.subject1.dataSets[1], dataSubject: 'subject1' })
+
+    const allDatasets = Object.entries(dataSubjects).map(([_, sub]) => sub.dataSets.map(ds => ds.value)).flat()
+    const uniqueDatasets = new Set(allDatasets)
+    expect(lookup.length).toBe(uniqueDatasets.length)
+  })
+
+  it('availableDatasets()', () => {
+    const datasets = util.availableDatasets(dataSubjects)
+    expect(new Set(datasets.map(ds => ds.value))).toEqual(new Set(['A', 'B']))
+  })
+})


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

- new route: '/check/link' which requires query params and
  redirects to the correct step in the wizard
- added DeepLinkController - to populate the session/history
  with passed query params
- new filter for generating a deep link (path+params)
- removed cookie parser (express docs say it's no longer needed and can
  actually cause issues)
- update check tool templates to display the dataset and organisation
  names when the wizard was entered via a deep link
- some utility functions/maps to simplify looking up datasets info
- moved a predicate out of DatasetController so it can be reused

## Related Tickets & Documents

- Closes #307 

## QA Instructions, Screenshots, Recordings

You can enter the check tool via one of the check service links on a dataset's "Get Started" page, for example: [here](https://submit-pr-550.herokuapp.com/organisations/local-authority:AYL/article-4-direction/get-started). This will take you to the check tool wizard form with some of the data pre-filled (notice it displays the dataset name): 

<img width="651" alt="image" src="https://github.com/user-attachments/assets/719f387d-db00-4855-a03b-98116eae6d80">

Note: clicking "back" to the "choose dataset"  will reset the journey and remove the dataset name from the heading (as if you started the form from the beginning, not through a deep link)

## Added/updated tests?

- [x] Yes
