### PR TITLE
CI: End-to-end tests using Hurl

### DIFF
--- a/.github/actions/hurl-setup/action.yml
+++ b/.github/actions/hurl-setup/action.yml
@@ -1,0 +1,10 @@
+name: "Hurl Setup"
+description: "Installs hurl (hurl.dev)"
+runs:
+  using: 'composite'
+  steps:
+    - id: install-hurl
+      shell:  bash
+      run: |
+        curl --location --remote-name https://github.com/Orange-OpenSource/hurl/releases/download/5.0.1/hurl_5.0.1_amd64.deb
+        sudo dpkg -i hurl_5.0.1_amd64.deb

--- a/.github/actions/hurl-test/action.yml
+++ b/.github/actions/hurl-test/action.yml
@@ -1,0 +1,23 @@
+name: "Hurl Test"
+description: "Runs hurl tests (hurl.dev)"
+inputs:
+  app_host:
+    description: "The host of the app to test (including the port)"
+    required: false
+    default: 'http://localhost:8085'
+  report_dir:
+    description: "The directory to store test report in. If not set, hurl will not generate a report."
+    required: false
+    default: ''
+runs:
+  using: 'composite'
+  steps:
+    - id: run-hurl
+      shell: bash
+      env:
+        HURL_app_host: ${{ inputs.app_host }}
+        HURL_report_dir: ${{ inputs.report_dir }}
+      run: |
+        mkdir -p test/hurl/common
+        curl --location -o test/hurl/common/geox-geoy-example.csv https://gist.githubusercontent.com/rosado/3994e2420857d5c6b0e3bd8dc1488aa1/raw/bf1b52316f66a480a6d116c993ffd57d119094f9/geox-geoy-example.csv
+        test/hurl/runner.sh

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -1,0 +1,22 @@
+name: Run end-to-end tests
+run-name: Run end to end tests on '${{ inputs.host }}' by @${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      host:
+        required: true
+        type: string
+        description: Host to test against (e.g. https://example.com:8080)
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    environment: development
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/hurl-setup
+      - uses: ./.github/actions/hurl-test
+        with:
+          app_host: ${{ inputs.host }}
+          report_dir: 'hurl-test-report-${{ github.run_number }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,19 @@ jobs:
       - name: Run unit tests
         run: npm run test:unit
 
+      - uses: ./.github/actions/hurl-setup
+      - uses: ./.github/actions/hurl-test
+        with:
+          app_host: http://localhost:8085
+          report_dir: 'hurl-test-report'
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: hurl-test-report
+          path: hurl-test-report/
+          retention-days: 30
+
       - uses: ./.github/actions/playwright-setup
       - name: Run integration tests
         run: npm run test:integration      

--- a/test/hurl/307-missin-params.hurl
+++ b/test/hurl/307-missin-params.hurl
@@ -1,0 +1,10 @@
+# accessing the route without required params should return an error
+GET {{ app_host }}/check/link
+HTTP 302
+[Asserts]
+header "Location" == "/check"
+
+GET {{ app_host }}/check/link?dataset=foo
+HTTP 302
+[Asserts]
+header "Location" == "/check"

--- a/test/hurl/307-missin-params.hurl
+++ b/test/hurl/307-missin-params.hurl
@@ -1,4 +1,6 @@
-# accessing the route without required params should return an error
+# SCENARIO: Enter the check tool via deep link, but without required params. This should
+# redirect us to the check tool start page.
+
 GET {{ app_host }}/check/link
 HTTP 302
 [Asserts]

--- a/test/hurl/307-submit-file.hurl
+++ b/test/hurl/307-submit-file.hurl
@@ -1,0 +1,45 @@
+GET {{ app_host }}/check/link
+[QueryStringParams]
+dataset: conservation-area
+orgName: Some Organisation
+HTTP 302
+[Captures]
+session-id: cookie "connect.sid"
+upload-method-location: header "Location"
+
+GET {{ app_host }}{{ upload-method-location }}
+[Cookies]
+connect.sid: {{ session-id }}
+HTTP 200
+[Asserts]
+xpath "string(/html/head/title)" contains "How do you want to provide your data"
+
+POST {{ app_host }}{{ upload-method-location }}
+[Cookies]
+connect.sid: {{ session-id }}
+[FormParams]
+upload-method: file
+HTTP 302
+[Captures]
+upload-url: header "Location"
+
+GET {{ app_host }}{{ upload-url }}
+HTTP 200
+[Asserts]
+xpath "string(/html/head/title)" contains "Upload data"
+
+POST {{ app_host }}{{ upload-url }}
+[Cookies]
+connect.sid: {{ session-id }}
+[MultipartFormData]
+datafile: file,common/geox-geoy-example.csv;
+HTTP 302
+[Captures]
+status-url: header "Location"
+
+GET {{ app_host }}{{ status-url }}
+[Cookies]
+connect.sid: {{ session-id }}
+HTTP 200
+[Asserts]
+xpath "string(/html/head/title)" contains "Status"

--- a/test/hurl/307-submit-file.hurl
+++ b/test/hurl/307-submit-file.hurl
@@ -1,3 +1,5 @@
+# SCENARIO: Successfully submit a dataset by uploading a file via check tool deep link .
+
 GET {{ app_host }}/check/link
 [QueryStringParams]
 dataset: conservation-area

--- a/test/hurl/307-submit-go-back.hurl
+++ b/test/hurl/307-submit-go-back.hurl
@@ -1,3 +1,6 @@
+# SCENARIO: Enter the check tool via deep link, go forward and then back go
+# back to the dataset selection page using the navigation links.
+
 GET {{ app_host }}/check/link
 [QueryStringParams]
 dataset: conservation-area

--- a/test/hurl/307-submit-go-back.hurl
+++ b/test/hurl/307-submit-go-back.hurl
@@ -1,0 +1,20 @@
+GET {{ app_host }}/check/link
+[QueryStringParams]
+dataset: conservation-area
+orgName: Some Organisation
+HTTP 302
+[Captures]
+session-id: cookie "connect.sid"
+upload-method-location: header "Location"
+
+GET {{ app_host }}{{ upload-method-location }}
+[Cookies]
+connect.sid: {{ session-id }}
+HTTP 200
+[Asserts]
+xpath "string(/html/head/title)" contains "How do you want to provide your data"
+
+GET {{ app_host }}/check/dataset
+[Cookies]
+connect.sid: {{ session-id }}
+HTTP 200

--- a/test/hurl/307-submit-tree-url.hurl
+++ b/test/hurl/307-submit-tree-url.hurl
@@ -1,3 +1,6 @@
+# SCENARIO: Successfully submit a 'tree' dataset URL via check tool deep link. This should trigger the
+# geometry type selection page.
+
 GET {{ app_host }}/check/link
 [QueryStringParams]
 dataset: tree

--- a/test/hurl/307-submit-tree-url.hurl
+++ b/test/hurl/307-submit-tree-url.hurl
@@ -1,0 +1,56 @@
+GET {{ app_host }}/check/link
+[QueryStringParams]
+dataset: tree
+orgName: Some Organisation
+HTTP 302
+[Captures]
+session-id: cookie "connect.sid"
+geometry-type-location: header "Location"
+
+GET {{ app_host }}{{ geometry-type-location }}
+[Cookies]
+connect.sid: {{ session-id }}
+HTTP 200
+[Asserts]
+xpath "string(/html/head/title)" contains "Is your geometry data given as points or polygons"
+
+POST {{ app_host }}{{ geometry-type-location }}
+[Cookies]
+connect.sid: {{ session-id }}
+[FormParams]
+geomType: point
+# alternatively, geomType: polygon
+HTTP 302
+[Captures]
+upload-method-location: header "Location"
+
+GET {{ app_host }}{{ upload-method-location }}
+[Cookies]
+connect.sid: {{ session-id }}
+HTTP 200
+[Asserts]
+xpath "string(/html/head/title)" contains "How do you want to provide your data"
+
+POST {{ app_host }}{{ upload-method-location }}
+[Cookies]
+connect.sid: {{ session-id }}
+[FormParams]
+upload-method: url
+HTTP 302
+[Captures]
+upload-url: url
+
+POST {{ app_host }}/check/url
+[Cookies]
+connect.sid: {{session-id}}
+[FormParams]
+url: https://gist.githubusercontent.com/rosado/3994e2420857d5c6b0e3bd8dc1488aa1/raw/bf1b52316f66a480a6d116c993ffd57d119094f9/geox-geoy-example.csv
+HTTP 302
+[Captures]
+status-url: header "Location"
+
+GET {{ app_host }}{{ status-url }}
+HTTP 200
+[Asserts]
+xpath "string(/html/head/title)" contains "Status"
+

--- a/test/hurl/307-submit-url.hurl
+++ b/test/hurl/307-submit-url.hurl
@@ -1,0 +1,39 @@
+GET {{ app_host }}/check/link
+[QueryStringParams]
+dataset: conservation-area
+orgName: Some Organisation
+HTTP 302
+[Captures]
+session-id: cookie "connect.sid"
+upload-method-location: header "Location"
+
+GET {{ app_host }}{{ upload-method-location }}
+[Cookies]
+connect.sid: {{ session-id }}
+HTTP 200
+[Asserts]
+xpath "string(/html/head/title)" contains "How do you want to provide your data"
+xpath "string(/html/body/div[2]/main/div/div/form/span)" contains "Conservation area dataset"
+
+POST {{ app_host }}{{ upload-method-location }}
+[Cookies]
+connect.sid: {{ session-id }}
+[FormParams]
+upload-method: url
+HTTP 302
+[Captures]
+upload-url: url
+
+POST {{ app_host }}/check/url
+[Cookies]
+connect.sid: {{ session-id }}
+[FormParams]
+url: https://gist.githubusercontent.com/rosado/3994e2420857d5c6b0e3bd8dc1488aa1/raw/bf1b52316f66a480a6d116c993ffd57d119094f9/geox-geoy-example.csv
+HTTP 302
+[Captures]
+status-url: header "Location"
+
+GET {{ app_host }}{{ status-url }}
+HTTP 200
+[Asserts]
+xpath "string(/html/head/title)" contains "Status"

--- a/test/hurl/307-submit-url.hurl
+++ b/test/hurl/307-submit-url.hurl
@@ -1,3 +1,5 @@
+# SCENARIO: Successfully submit a dataset via URL via check tool deep link.
+
 GET {{ app_host }}/check/link
 [QueryStringParams]
 dataset: conservation-area

--- a/test/hurl/runner.sh
+++ b/test/hurl/runner.sh
@@ -1,0 +1,36 @@
+# arguments:
+#  FILE_OR_DIR  - optional, name of the file to run, if not provided, runs all scripts
+#
+# env:
+#  HURL_app_host - optional, defaults to "http://localhost:5000"
+#  HURL_report_dir - optional
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+app_host="${HURL_app_host:-"http://localhost:5000"}"
+report_dir="${HURL_report_dir:-""}"
+test_file="${1:-"${script_dir}"}"
+
+report_option=""
+if [ -n "${report_dir}" ]; then
+  report_option="--report-html ${report_dir}"
+fi
+
+echo
+echo "ℹ️  Running scripts in directory $script_dir"
+echo "ℹ️  app_host=${app_host}"
+echo
+
+function run_hurl() {
+  local file=$1
+  hurl --test ${report_option} \
+       --variable app_host="${app_host}" \
+        ${file}
+}
+
+if [ -z "${test_file}" ]; then
+  run_hurl "${script_dir}"
+else
+  echo " running single test"
+  run_hurl ${test_file}
+fi


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

This PR adds a set of [Hurl](https://hurl.dev) scripts (in `test/hurl`) that that exercise the deep linking functionality. The scripts are meant to illustrate how Hurl can be used for end-to-end testing. 

It also adds new GH actions and workflow for 
- running the tests in CI 
- allowing to run the tests against a specified host via Github actions UI (this workflow is only available when on main branch)

Notice that the extra tooling consists of one binary (`hurl`), so no need to install node (and no `npm install`) and runs fast (granted, only few tests are present, but it gives you the idea). I also recommend checking out the `hurl-test-report` [artifact](https://github.com/digital-land/submit/actions/runs/11437960842). 

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

First, you need to install [Hurl](http://hurl.dev/).

Then download example data (the workflow does it on it's own, but in the end we most likely want the test data in the repo):

```
mkdir -p `test/hurl/common`
curl --location -o test/hurl/common/geox-geoy-example.csv https://gist.githubusercontent.com/rosado/3994e2420857d5c6b0e3bd8dc1488aa1/raw/bf1b52316f66a480a6d116c993ffd57d119094f9/geox-geoy-example.csv
```
Then you can run the test against the local environment, by running:

```
./test/hurl/runner.sh
```

Or against staging:

```
HURL_app_host="https://submit.staging.digital-land.info"  ./test/hurl/runner.sh
```

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
