### PR TITLE
Check Tool: 'back' link takes user to referrer page , when arriving via deep link.

### DIFF
--- a/src/controllers/deepLinkController.js
+++ b/src/controllers/deepLinkController.js
@@ -33,8 +33,11 @@ class DeepLinkController extends PageController {
     req.sessionModel.set('dataset', dataset)
     const datasetInfo = datasets.get(dataset) ?? { dataSubject: '', requiresGeometryTypeSelection: false }
     req.sessionModel.set('data-subject', datasetInfo.dataSubject)
-    req.sessionModel.set(this.checkToolDeepLinkSessionKey,
-      { 'data-subject': datasetInfo.dataSubject, orgName, dataset, datasetName: datasetInfo.text })
+    const sessionData = { 'data-subject': datasetInfo.dataSubject, orgName, dataset, datasetName: datasetInfo.text }
+    if (req.headers.referer) {
+      sessionData.referer = req.headers.referer
+    }
+    req.sessionModel.set(this.checkToolDeepLinkSessionKey, sessionData)
 
     this.#addHistoryStep(req, '/check/dataset')
 

--- a/src/controllers/deepLinkController.js
+++ b/src/controllers/deepLinkController.js
@@ -35,7 +35,7 @@ class DeepLinkController extends PageController {
     req.sessionModel.set('data-subject', datasetInfo.dataSubject)
     const sessionData = { 'data-subject': datasetInfo.dataSubject, orgName, dataset, datasetName: datasetInfo.text }
     if (req.headers.referer) {
-      sessionData.referer = req.headers.referer
+      sessionData.referrer = req.headers.referer
     }
     req.sessionModel.set(this.checkToolDeepLinkSessionKey, sessionData)
 

--- a/src/controllers/pageController.js
+++ b/src/controllers/pageController.js
@@ -6,14 +6,16 @@ const { Controller } = hmpoFormWizard
  * If we arrived at the page via deep from another page, we'll use that page as the back link.
  *
  * @param {string} url current page URL
- * @param {{ referer?: string }} deepLinkInfo deep link info from the session
+ * @param {{ referer?: string, dataset: string }} deepLinkInfo deep link info from the session
  * @returns {string|undefined} back link URL
  */
 function wizardBackLink (currentUrl, deepLinkInfo) {
   if (deepLinkInfo && 'referer' in deepLinkInfo) {
-    const { referer } = deepLinkInfo
-    const entryPoint = '/check/upload-method'
-    if (referer && currentUrl === entryPoint) {
+    const { referer, dataset } = deepLinkInfo
+    if (dataset === 'tree' && currentUrl === '/check/geometry-type') {
+      return referer
+    }
+    if (dataset !== 'tree' && currentUrl === '/check/upload-method') {
       return referer
     }
   }

--- a/src/controllers/pageController.js
+++ b/src/controllers/pageController.js
@@ -33,7 +33,7 @@ class PageController extends Controller {
 
   locals (req, res, next) {
     let backLink
-    const deepLinkInfo = req.sessionModel.get(this.checkToolDeepLinkSessionKey)
+    const deepLinkInfo = req?.sessionModel?.get(this.checkToolDeepLinkSessionKey)
     if (deepLinkInfo) {
       req.form.options.deepLink = deepLinkInfo
       backLink = wizardBackLink(req.originalUrl, deepLinkInfo)

--- a/src/controllers/pageController.js
+++ b/src/controllers/pageController.js
@@ -31,10 +31,12 @@ class PageController extends Controller {
 
   locals (req, res, next) {
     let backLink
-    if (req.sessionModel) {
-      const deepLinkInfo = req.sessionModel.get(this.checkToolDeepLinkSessionKey)
+    const deepLinkInfo = req.sessionModel.get(this.checkToolDeepLinkSessionKey)
+    if (deepLinkInfo) {
+      req.form.options.deepLink = deepLinkInfo
       backLink = wizardBackLink(req.originalUrl, deepLinkInfo)
     }
+
     backLink = backLink ?? this.options.backLink
     if (backLink) {
       req.form.options.lastPage = backLink

--- a/src/controllers/pageController.js
+++ b/src/controllers/pageController.js
@@ -6,17 +6,17 @@ const { Controller } = hmpoFormWizard
  * If we arrived at the page via deep from another page, we'll use that page as the back link.
  *
  * @param {string} url current page URL
- * @param {{ referer?: string, dataset: string }} deepLinkInfo deep link info from the session
+ * @param {{ referrer?: string, dataset: string }} deepLinkInfo deep link info from the session
  * @returns {string|undefined} back link URL
  */
 function wizardBackLink (currentUrl, deepLinkInfo) {
-  if (deepLinkInfo && 'referer' in deepLinkInfo) {
-    const { referer, dataset } = deepLinkInfo
+  if (deepLinkInfo && 'referrer' in deepLinkInfo) {
+    const { referrer, dataset } = deepLinkInfo
     if (dataset === 'tree' && currentUrl === '/check/geometry-type') {
-      return referer
+      return referrer
     }
     if (dataset !== 'tree' && currentUrl === '/check/upload-method') {
-      return referer
+      return referrer
     }
   }
 

--- a/src/controllers/pageController.js
+++ b/src/controllers/pageController.js
@@ -1,5 +1,6 @@
 import hmpoFormWizard from 'hmpo-form-wizard'
-import { logPageView } from '../utils/logging.js'
+import { logPageView, types } from '../utils/logging.js'
+import logger from '../utils/logger.js'
 const { Controller } = hmpoFormWizard
 
 /**
@@ -32,17 +33,25 @@ class PageController extends Controller {
   }
 
   locals (req, res, next) {
-    let backLink
-    const deepLinkInfo = req?.sessionModel?.get(this.checkToolDeepLinkSessionKey)
-    if (deepLinkInfo) {
-      req.form.options.deepLink = deepLinkInfo
-      backLink = wizardBackLink(req.originalUrl, deepLinkInfo)
+    try {
+      let backLink
+      const deepLinkInfo = req?.sessionModel?.get(this.checkToolDeepLinkSessionKey)
+      if (deepLinkInfo) {
+        req.form.options.deepLink = deepLinkInfo
+        backLink = wizardBackLink(req.originalUrl, deepLinkInfo)
+      }
+
+      backLink = backLink ?? this.options.backLink
+      if (backLink) {
+        req.form.options.lastPage = backLink
+      }
+    } catch (e) {
+      logger.warn('PageController.locals(): error setting back link', {
+        type: types.App,
+        errorMessage: e.message
+      })
     }
 
-    backLink = backLink ?? this.options.backLink
-    if (backLink) {
-      req.form.options.lastPage = backLink
-    }
     super.locals(req, res, next)
   }
 }

--- a/test/unit/PageController.test.js
+++ b/test/unit/PageController.test.js
@@ -41,7 +41,7 @@ describe('PageController', () => {
 })
 
 describe('Correctly detects the wizard back link', () => {
-  const referrer = '/this-is-where-we-came-from'
+  const referrer = 'https://example.com/this-is-where-we-came-from'
   const makeReq = () => {
     return ({
       originalUrl: '/check/upload-method',

--- a/test/unit/PageController.test.js
+++ b/test/unit/PageController.test.js
@@ -39,3 +39,48 @@ describe('PageController', () => {
     expect(callArgs.service).toEqual('lpa-data-validation-frontend')
   })
 })
+
+describe('Correctly detects the wizard back link', () => {
+  const referer = '/this-is-where-we-came-from'
+  const makeReq = () => {
+    return ({
+      originalUrl: '/check/upload-method',
+      sessionID: '123',
+      sessionModel: {
+        get: vi.fn().mockReturnValue({ referer })
+      },
+      form: {
+        options: {}
+      }
+    })
+  }
+
+  it('arriving at the deep link entry point', () => {
+    const pageController = new PageController({ route: '/upload-method' })
+    const req = makeReq()
+    pageController.locals(req, {}, vi.fn())
+    expect(req.form.options.lastPage).toEqual(referer)
+  })
+
+  it('arriving at some other step', () => {
+    const pageController = new PageController({ route: '/upload-method' })
+    const req = { ...makeReq(), originalUrl: '/check/another-step' }
+    pageController.locals(req, {}, vi.fn())
+    expect(req.form.options.lastPage).toBe(undefined)
+  })
+
+  it('don\'t touch the back link if there\'s no deep link session info (lastPage not set)', () => {
+    const pageController = new PageController({ route: '/upload-method' })
+    const req = { ...makeReq(), sessionModel: new Map() }
+    pageController.locals(req, {}, vi.fn())
+    expect(req.form.options.lastPage).toEqual(undefined)
+  })
+
+  it('don\'t touch the back link if there\'s no deep link session info (lastPage set)', () => {
+    const pageController = new PageController({ route: '/upload-method' })
+    pageController.options.backLink = '/go-back'
+    const req = { ...makeReq(), sessionModel: new Map() }
+    pageController.locals(req, {}, vi.fn())
+    expect(req.form.options.lastPage).toEqual('/go-back')
+  })
+})

--- a/test/unit/PageController.test.js
+++ b/test/unit/PageController.test.js
@@ -41,13 +41,13 @@ describe('PageController', () => {
 })
 
 describe('Correctly detects the wizard back link', () => {
-  const referer = '/this-is-where-we-came-from'
+  const referrer = '/this-is-where-we-came-from'
   const makeReq = () => {
     return ({
       originalUrl: '/check/upload-method',
       sessionID: '123',
       sessionModel: {
-        get: vi.fn().mockReturnValue({ referer })
+        get: vi.fn().mockReturnValue({ referrer })
       },
       form: {
         options: {}
@@ -59,7 +59,7 @@ describe('Correctly detects the wizard back link', () => {
     const pageController = new PageController({ route: '/upload-method' })
     const req = makeReq()
     pageController.locals(req, {}, vi.fn())
-    expect(req.form.options.lastPage).toEqual(referer)
+    expect(req.form.options.lastPage).toEqual(referrer)
   })
 
   it('arriving at some other step', () => {

--- a/test/unit/deepLinkController.test.js
+++ b/test/unit/deepLinkController.test.js
@@ -4,7 +4,7 @@ import DeepLinkController from '../../src/controllers/deepLinkController.js'
 function mockRequestObject () {
   const sessionModel = new Map()
   const journeyModel = new Map()
-  return { sessionModel, journeyModel, query: {} }
+  return { sessionModel, journeyModel, query: {}, headers: {} }
 }
 
 function mockMiddlewareArgs (reqOpts) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Sets the "back" link on page user arrives at via a deep link to the linked _from_ page (using the `referer` header when available).

## Related Tickets & Documents

- Related Issue: #550 
- Closes #557

## QA Instructions, Screenshots, Recordings

Go to a task list of any dataset and click the "check service" link, for example
- [LBH: article-4-direction-area ](https://submit-pr-584.herokuapp.com/organisations/local-authority:LBH/article-4-direction-area)
- [LBH: tree](https://submit-pr-584.herokuapp.com/organisations/local-authority:LBH/tree)

Then click the "Back" link. It should take you back to the task list page.

<img width="674" alt="image" src="https://github.com/user-attachments/assets/acab3506-d9e1-4041-9a76-c53e87b587da">

Also worth checking: the "Back" links on further steps **do not** take you to the task list page.

Note: there is a limitation/bug where going "back" from the upload type will always take you to the `/dataset` step. This is a limitation in the wizard library (this behaviour is already present in production). 

## Added/updated tests?

- [x] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced session data to include referrer information when valid.
	- Introduced a new method to determine the back link URL based on deep link information.

- **Bug Fixes**
	- Improved logic for back link assignment in the PageController, including error handling.

- **Tests**
	- Added a test suite for validating back link detection in various scenarios.
	- Enhanced mock request object for more comprehensive testing of HTTP headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->