### PR TITLE
NOTICKET: correctly ensure entityCount is number

### DIFF
--- a/src/services/performanceDbApi.js
+++ b/src/services/performanceDbApi.js
@@ -106,7 +106,7 @@ export function lpaOverviewQuery (lpa, params) {
 
   const entityCountsSelects = []
   for (const { resource, dataset, entityCount } of params.entityCounts) {
-    if (entityCount && entityCount >= 0) {
+    if (Number.isInteger(entityCount) && entityCount >= 0) {
       entityCountsSelects.push(entityCountSelectFragment(dataset, resource, entityCount))
     }
   }

--- a/test/unit/performanceDbApi.test.js
+++ b/test/unit/performanceDbApi.test.js
@@ -48,11 +48,15 @@ describe('performanceDbApi', () => {
     it('uses params in the query', () => {
       const query = lpaOverviewQuery('local-authority:FOO', {
         datasetsFilter: ['dataset-one', 'dataset-two'],
-        entityCounts: [{ dataset: 'dataset-three', resource: 'r1', entityCount: 10 }]
+        entityCounts: [
+          { dataset: 'dataset-three', resource: 'r1', entityCount: 10 },
+          { dataset: 'dataset-four', resource: 'r2', entityCount: 0 }]
       })
       expect(query).toContain('local-authority:FOO')
       expect(query).toContain('dataset-one')
       expect(query).toContain('dataset-two')
+      expect(query).toContain('dataset-three')
+      expect(query).toContain('dataset-four')
     })
   })
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

A condition would always fail for `entityCount = 0`.

The clauses inserted into the query were used with an outer join, so this bug did not narrow down the result set. In fact the results would still contain the correct value of zero in the `entity_count` column. 

## Related Tickets & Documents

No ticket.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation for `entityCount` in queries to ensure only integer values are accepted.
  
- **Tests**
	- Expanded test coverage for the `lpaOverviewQuery` function to include additional datasets and validate outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->