### PR TITLE
update 'no-errors' page design & content

### DIFF
--- a/src/views/check/results/no-errors.html
+++ b/src/views/check/results/no-errors.html
@@ -17,6 +17,11 @@
   {% set dataLooksCorrectError = true %}
 {% endif %}
 
+{% if options.data.params.dataset %}
+  {% set checkToolLink = { name: (options.deepLink.orgName or '') } | checkToolDeepLink(options.data.params) %}
+{% else %}
+  {% set checkToolLink = "/check" %}
+{% endif %}
 
 {% block pageTitle %}
   {% set pageTitle = super() %}
@@ -40,7 +45,7 @@
         {{ datasetBanner(options.datasetName) }}
       {% endif %}
       <h1 class="govuk-heading-l">
-        {{pageName}}
+        You have {{options.pagination.totalResults}} {{ "row" | pluralise(options.pagination.totalResults) }} ready to publish
       </h1>
       <p>{{options.buttonText}}</p>
     </div>
@@ -48,10 +53,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <p>{{options.pagination.totalResults}} rows can be published.</p>
 
-
-        
       {{ table(options.tableParams) }}
 
       {% if options.pagination.items | length > 1 %}
@@ -79,46 +81,21 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% if dataLooksCorrectError %}
-        {{ govukErrorSummary({
-          titleText: "There’s a problem",
-          errorList: [
-            {
-              text: errorMessage,
-              href: "#dataLooksCorrect"
-            }
-          ]
-        }) }}
-      {% endif %}
-      <form method="post">
-        {{ govukRadios({
-            idPrefix: "dataLooksCorrect",
-            name: "dataLooksCorrect",
-            fieldset: {
-              legend: {
-                text: "Is your data correct?",
-                isPageHeading: false,
-                classes: "govuk-fieldset__legend--m"
-              }
-            },
-            items: [
-              {
-                value: "yes",
-                text: "Yes"
-              },
-              {
-                value: "no",
-                text: "No, I need to fix it"
-              }
-            ],
-            errorMessage: {
-              text: errorMessage 
-            } if dataLooksCorrectError else undefined
-          }) 
-        }}
+
+      <form novalidate method="post">
+        <h3 class="govuk-heading-m">Before you continue</h3>
+
+        <p>Make sure your data is correct.</p>
+
+        <p>If you see anything wrong with your data, you can check it again.</p>
+
         {{ govukButton({
           text: "Continue"
         }) }}
+
+        <input type="hidden" name="dataLooksCorrect" value="yes">
+        <p><a href="{{ checkToolLink  }}">Check your updated data</a></p>
+
       </form>
     </div>
   </div>

--- a/test/PageObjectModels/resultsPage.js
+++ b/test/PageObjectModels/resultsPage.js
@@ -16,7 +16,7 @@ export default class ResultsPage extends BasePage {
   }
 
   async expectPageIsNoErrorsPage () {
-    expect(await this.page.locator('h1').innerText()).toMatch(/You have \d+ row? ready to publish/)
+    expect(await this.page.locator('h1').innerText()).toMatch(/You have \d+ row.* ready to publish/)
   }
 
   async expectIsFailedPage () {

--- a/test/PageObjectModels/resultsPage.js
+++ b/test/PageObjectModels/resultsPage.js
@@ -16,7 +16,7 @@ export default class ResultsPage extends BasePage {
   }
 
   async expectPageIsNoErrorsPage () {
-    expect(await this.page.locator('h1').innerText()).toEqual('Check your data before you continue')
+    expect(await this.page.locator('h1').innerText()).toMatch(/You have \d+ row? ready to publish/)
   }
 
   async expectIsFailedPage () {

--- a/test/acceptance/request_check.test.js
+++ b/test/acceptance/request_check.test.js
@@ -44,7 +44,6 @@ test.describe('Request Check', () => {
       await resultsPage.waitForPage(id)
       await resultsPage.expectPageIsNoErrorsPage()
 
-      await resultsPage.selectLabel('Yes')
       const confirmationPage = await resultsPage.clickContinue()
       await confirmationPage.waitForPage()
     })
@@ -170,7 +169,6 @@ test.describe('Request Check', () => {
       await resultsPage.waitForPage(id)
       await resultsPage.expectPageIsNoErrorsPage()
 
-      await resultsPage.selectLabel('Yes')
       const confirmationPage = await resultsPage.clickContinue()
       await confirmationPage.waitForPage()
     })

--- a/test/integration/test_recieving_results.playwright.test.js
+++ b/test/integration/test_recieving_results.playwright.test.js
@@ -24,7 +24,7 @@ test('receiving a successful result', async ({ page }) => {
   await resultsPage.navigateToRequest('complete')
   await resultsPage.expectPageIsNoErrorsPage()
 
-  await expect(page.locator('#main-content')).toContainText('3 rows can be published.')
+  await expect(page.locator('#main-content')).toContainText(/You have \d+ row.* ready to publish/)
 
   const tableValues = await getTableContents(page, 'govuk-table')
   const expectedTableValues = getTableValuesFromResponse(successResponse, successResponseDetails)

--- a/test/integration/validation_errors.playwright.test.js
+++ b/test/integration/validation_errors.playwright.test.js
@@ -1,7 +1,5 @@
 import { test } from '@playwright/test'
 import StartPage from '../PageObjectModels/startPage'
-import NoErrorsPage from '../PageObjectModels/noErrorsPage'
-
 import { datasets } from '../PageObjectModels/datasetPage'
 import { uploadMethods } from '../PageObjectModels/uploadMethodPage'
 

--- a/test/integration/validation_errors.playwright.test.js
+++ b/test/integration/validation_errors.playwright.test.js
@@ -104,19 +104,3 @@ test('when the user clicks continue on the url page without entering a url, the 
 
   await uploadURLPage.expectErrorMessages(expectedErrors)
 })
-
-// ToDo: rewrite this for the new async flow
-test('when the user clicks continue on the no errors page, without saying their data looks ok, the page correctly indicates there\'s an error', async ({ page }) => {
-  const noErrorsPage = new NoErrorsPage(page)
-
-  await noErrorsPage.navigateToRequest('complete')
-  await noErrorsPage.clickContinue(true)
-
-  const expectedErrors = [
-    {
-      fieldName: 'input#dataLooksCorrect.govuk-radios__input',
-      expectedErrorMessage: 'Select if your data looks ok'
-    }
-  ]
-  await noErrorsPage.expectErrorMessages(expectedErrors)
-})


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Update design and content of the 'no-errors' template, and a deep link into the check tool.

## Related Tickets & Documents

- Related Issue #571 

## QA Instructions, Screenshots, Recordings

Top of the page now looks like this:
![image](https://github.com/user-attachments/assets/b24d8f81-38db-45f0-9717-b46b1cc3f6a0)

Bottom of the page looks like this:
![image](https://github.com/user-attachments/assets/8d8dde3b-c1d6-48ae-a706-6bf24e38877a)


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced user interface on the "no errors" page, displaying the number of rows ready for publication.
	- Improved page title clarity by indicating errors and pagination information.

- **Bug Fixes**
	- Streamlined form interactions by removing unnecessary elements and ensuring data correctness prompts are clear.

- **Tests**
	- Updated acceptance and integration tests to reflect changes in the user interface and improve assertion flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->