### PR TITLE
608 check not accepting endpoints

### DIFF
--- a/src/controllers/submitUrlController.js
+++ b/src/controllers/submitUrlController.js
@@ -63,18 +63,16 @@ class SubmitUrlController extends UploadController {
       { type: 'filetype', fn: () => SubmitUrlController.validateAcceptedFileType(resp) },
       { type: 'size', fn: () => SubmitUrlController.urlResponseIsNotTooLarge(resp) }
     ])
-    let headResponse
-    try {
-      headResponse = await SubmitUrlController.headRequest(url)
-    } catch (error) {
-      logger.warn('submitUrlController/localUrlValidation: failed to get the submitted urls head. skipping post validators', {
-        type: types.DataFetch,
-        errorMessage: error.message
+    const headResponse = await SubmitUrlController.headRequest(url)
+
+    if (!headResponse) {
+      logger.warn('submitUrlController/localUrlValidation: failed to get the submitted urls head, skipping post validators', {
+        type: types.DataFetch
       })
       return null
     }
 
-    if (headResponse.status === HTTP_STATUS_METHOD_NOT_ALLOWED) {
+    if (headResponse?.status === HTTP_STATUS_METHOD_NOT_ALLOWED) {
       // HEAD request not allowed, return null or a specific error message
       logger.warn('submitUrlController/localUrlValidation: failed to get the submitted urls head as it was not allowed (405) skipping post validators', {
         type: types.DataFetch

--- a/test/unit/submitUrlController.test.js
+++ b/test/unit/submitUrlController.test.js
@@ -130,6 +130,18 @@ describe('SubmitUrlController', async () => {
         url += 'a'.repeat(2048)
         expect(await SubmitUrlController.localUrlValidation(url)).toBe('length')
       })
+
+      it('should return null if the head request fails', async () => {
+        mocks.headMock.mockImplementation(() => { throw new Error('Head request failed') })
+        const url = 'http://example.com'
+        expect(await SubmitUrlController.localUrlValidation(url)).toBeNull()
+      })
+
+      it('should return null if the head request method is not allowed', async () => {
+        mocks.headMock.mockImplementation(() => ({ status: 405 }))
+        const url = 'http://example.com'
+        expect(await SubmitUrlController.localUrlValidation(url)).toBeNull()
+      })
     })
 
     describe('urlIsValid', () => {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- Bug Fix

## Description
after a url is submitted in check, During local validation when we get the HEAD object of the url. if the server that hosts the submitted URL doesn't allow head requests, or if the head request fails. don't attempt to perform validations on the head object

## Related Tickets & Documents
- Closes #608 

## QA Instructions, Screenshots, Recordings
You can test with this known endpoint, where a head request returns status 405 (method not allowed). but the file itself is valid and should return some check results

## Added/updated tests?
- Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for URL validation, specifically for HEAD requests.
  
- **Bug Fixes**
	- Improved handling of scenarios where HEAD requests fail or are not allowed (HTTP status 405).

- **Tests**
	- Added new test cases for the URL validation method to cover failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->