### PR TITLE
check tool: update 'errors' page design & content

### DIFF
--- a/src/content/statusPage.js
+++ b/src/content/statusPage.js
@@ -1,6 +1,6 @@
 export const headingTexts = {
   checking: 'Checking your data',
-  checked: 'Data Checked'
+  checked: 'Data checked'
 }
 
 export const messageTexts = {

--- a/src/controllers/resultsController.js
+++ b/src/controllers/resultsController.js
@@ -64,7 +64,12 @@ class ResultsController extends PageController {
           fields: responseDetails.getFields()
         }
 
-        req.form.options.errorSummary = requestData.getErrorSummary()
+        req.form.options.errorSummary = requestData.getErrorSummary().map(message => {
+          return {
+            text: message,
+            href: ''
+          }
+        })
         req.form.options.mappings = responseDetails.getFieldMappings()
         req.form.options.geometries = responseDetails.getGeometries()
         req.form.options.pagination = responseDetails.getPagination(req.params.pageNumber)

--- a/src/controllers/resultsController.js
+++ b/src/controllers/resultsController.js
@@ -75,6 +75,7 @@ class ResultsController extends PageController {
         req.form.options.geometries = responseDetails.getGeometries()
         req.form.options.pagination = responseDetails.getPagination(req.params.pageNumber)
         req.form.options.id = req.params.id
+        req.form.options.lastPage = `/check/status/${req.params.id}`
       } else {
         req.form.options.error = requestData.getError()
       }

--- a/src/controllers/statusController.js
+++ b/src/controllers/statusController.js
@@ -3,6 +3,22 @@ import { getRequestData } from '../services/asyncRequestApi.js'
 import { finishedProcessingStatuses } from '../utils/utils.js'
 import { headingTexts, messageTexts } from '../content/statusPage.js'
 
+/**
+ * Attempts to infer how we ended up on this page.
+ *
+ * @param req
+ * @returns {string?}
+ */
+function getLastPage (req) {
+  let lastPage
+  if ('url' in req.form.options.data.params) {
+    lastPage = '/check/url'
+  } else if ('original_filename' in req.form.options.data.params) {
+    lastPage = '/check/upload'
+  }
+  return lastPage
+}
+
 class StatusController extends PageController {
   async locals (req, res, next) {
     try {
@@ -11,6 +27,10 @@ class StatusController extends PageController {
       req.form.options.headingTexts = headingTexts
       req.form.options.messageTexts = messageTexts
       req.form.options.pollingEndpoint = `/api/status/${req.form.options.data.id}`
+      const lastPage = getLastPage(req)
+      if (lastPage) {
+        req.form.options.lastPage = lastPage
+      }
       super.locals(req, res, next)
     } catch (error) {
       next(error, req, res, next)

--- a/src/models/requestData.js
+++ b/src/models/requestData.js
@@ -32,6 +32,10 @@ export default class ResultData {
     return new ResponseDetails(this.id, response.data, pagination, this.getColumnFieldLog())
   }
 
+  /**
+   *
+   * @returns {string[]}
+   */
   getErrorSummary () {
     if (!this.response || !this.response.data || !this.response.data['error-summary']) {
       logger.warn('trying to get error summary when there is none', { requestId: this.id })

--- a/src/views/check/confirmation.html
+++ b/src/views/check/confirmation.html
@@ -31,7 +31,7 @@
   Details about what to do next are also available [in the guidance](/guidance)
 
   {% if options.deepLink %}
-    <p><a href="{{ options.deepLink.referrer }}">Return to {{ options.deepLink.dataset }} overview</a></p>
+    <p><a href="{{ options.deepLink.referrer }}">Return to {{ options.deepLink.dataset | datasetSlugToReadableName }} overview</a></p>
   {% else %}
     <p><a href="/">Return to Home</a></p>
   {% endif %}

--- a/src/views/check/confirmation.html
+++ b/src/views/check/confirmation.html
@@ -1,4 +1,4 @@
-
+{% from 'govuk/components/back-link/macro.njk' import govukBackLink %}
 {% from 'govuk/components/panel/macro.njk' import govukPanel %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
@@ -6,6 +6,14 @@
 
 {% set serviceType = 'Check' %}
 {% set pageName = "You can now publish your data" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
 
 {% set content %}
 

--- a/src/views/check/results/errors.html
+++ b/src/views/check/results/errors.html
@@ -48,7 +48,7 @@
 
   <div class="govuk-grid-column-full">
     {% if options.geometries %}
-      <div id="map" class="app-map"></div>
+      <div id="map" class="app-map" aria-label="Map showing contour of the submitted data on a map"></div>
     {% endif %}
 
     {% if options.tableParams.rows|length > 0 %}

--- a/src/views/check/results/errors.html
+++ b/src/views/check/results/errors.html
@@ -4,6 +4,7 @@
 {% from 'govuk/components/radios/macro.njk' import govukRadios %}
 {% from 'govuk/components/inset-text/macro.njk' import govukInsetText %}
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
+{% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 {% from "../../components/table.html" import table %}
 {% from '../../components/dataset-banner.html' import datasetBanner %}
 
@@ -35,23 +36,17 @@
         {{pageName}}
       </h1>
 
-      <ul class="govuk-list govuk-list--bullet">
-        {% for summaryMessage in options.errorSummary %}
-          <li>
-            {{summaryMessage}}
-          </li>
-        {% endfor %}
-      </ul>
+      {{ govukErrorSummary({
+        titleText: "There’s a problem",
+        errorList: options.errorSummary
+      }) }}
+
   </div>
 </div>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     {% if options.tableParams.rows|length > 0 %}
-      <h2 class="govuk-heading-m">
-        Check your errors
-      </h2>
-
       {{ table(options.tableParams) }}
     {% endif %}
 
@@ -71,8 +66,20 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+
+    {% if options.deepLink.orgName %}
+      <h3 class="govuk-heading-m">How to improve {{ options.deepLink.orgName }}'s data</h3>
+    {% else %}
+      <h3 class="govuk-heading-m">How to improve the data</h3>
+    {% endif %}
+
+    <ol class="govuk-list govuk-list--number">
+      <li>Fix the errors indicated. You should use the <a href="/guidance/specifications/">data specifications</a> to help you do this.</li>
+      <li>Check your updated data to make sure it meets the specifications.</li>
+    </ol>
+
     {{ govukButton({
-      text: "Upload a new version",
+      text: "Check your data",
       href: "/check/upload-method"
     }) }}
 

--- a/src/views/check/results/errors.html
+++ b/src/views/check/results/errors.html
@@ -74,7 +74,7 @@
     {% endif %}
 
     <ol class="govuk-list govuk-list--number">
-      <li>Fix the errors indicated. You should use the <a href="/guidance/specifications/">data specifications</a> to help you do this.</li>
+      <li>Fix the errors indicated. You should use the <a href="https://www.planning.data.gov.uk/guidance/specifications/">data specifications</a> to help you do this.</li>
       <li>Check your updated data to make sure it meets the specifications.</li>
     </ol>
 

--- a/src/views/check/results/errors.html
+++ b/src/views/check/results/errors.html
@@ -74,7 +74,7 @@
     {% endif %}
 
     <ol class="govuk-list govuk-list--number">
-      <li>Fix the errors indicated. You should use the <a href="https://www.planning.data.gov.uk/guidance/specifications/">data specifications</a> to help you do this.</li>
+      <li>Fix the errors indicated. You should use the <a href="/guidance/specifications/">data specifications</a> to help you do this.</li>
       <li>Check your updated data to make sure it meets the specifications.</li>
     </ol>
 

--- a/src/views/check/results/errors.html
+++ b/src/views/check/results/errors.html
@@ -45,7 +45,12 @@
 </div>
 
 <div class="govuk-grid-row">
+
   <div class="govuk-grid-column-full">
+    {% if options.geometries %}
+      <div id="map" class="app-map"></div>
+    {% endif %}
+
     {% if options.tableParams.rows|length > 0 %}
       {{ table(options.tableParams) }}
     {% endif %}
@@ -85,4 +90,18 @@
 
   </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  {% if options.geometries %}
+    <link href='https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css' rel='stylesheet' />
+    <script>
+      window.serverContext = {
+        containerId: 'map',
+        geometries: {{ options.geometries | dump | safe }},
+      }
+    </script>
+    <script src="/public/js/map.bundle.js"></script>
+  {% endif %}
 {% endblock %}

--- a/src/views/check/results/no-errors.html
+++ b/src/views/check/results/no-errors.html
@@ -54,6 +54,10 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
 
+      {% if options.geometries %}
+        <div id="map" class="app-map"></div>
+      {% endif %}
+
       {{ table(options.tableParams) }}
 
       {% if options.pagination.items | length > 1 %}
@@ -66,13 +70,6 @@
           } if options.pagination.nextPage else undefined,
           items: options.pagination.items
         })}}
-      {% endif %}
-
-
-
-      {% if options.geometries %}
-        <p>Here’s your data on a map:</p>
-        <div id="map" class="app-map"></div>
       {% endif %}
 
 

--- a/src/views/check/results/no-errors.html
+++ b/src/views/check/results/no-errors.html
@@ -55,7 +55,7 @@
     <div class="govuk-grid-column-full">
 
       {% if options.geometries %}
-        <div id="map" class="app-map"></div>
+        <div id="map" class="app-map" aria-label="Map showing contour of the submitted data on a map"></div>
       {% endif %}
 
       {{ table(options.tableParams) }}

--- a/src/views/check/statusPage/status.html
+++ b/src/views/check/statusPage/status.html
@@ -1,4 +1,5 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from 'govuk/components/back-link/macro.njk' import govukBackLink %}
 {% from "./statusContentMacro.html" import statusContent %}
 {% from '../../components/dataset-banner.html' import datasetBanner %}
 
@@ -16,6 +17,15 @@
   {% set buttonText = "Retrieve Latest Status" %}
   {% set buttonClasses = "js-hidden" %}
 {% endif %}
+
+{% block beforeContent %}
+  {% if options.lastPage %}
+    {{ govukBackLink({
+      text: options.backLinkText | default("Back"),
+      href: options.lastPage
+    }) }}
+  {% endif %}
+{% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">

--- a/src/views/components/dataset-banner.html
+++ b/src/views/components/dataset-banner.html
@@ -1,3 +1,3 @@
 {% macro datasetBanner(datasetName) %}
-<span class="govuk-caption-xl">{{ datasetName }}</span>
+<span class="govuk-caption-xl">{{ datasetName | datasetSlugToReadableName }}</span>
 {% endmacro %}

--- a/src/views/components/table.html
+++ b/src/views/components/table.html
@@ -37,6 +37,11 @@
 {% macro table(params) %}
     <div class="app-scrollable-container dl-scrollable">
         <table class="govuk-table dl-table">
+            <colgroup>
+                {% for field in params.fields %}
+                    <col class="{% if (r/.*-date/g).test(field) %}govuk-table__cell--numeric{% endif %}" />
+                {% endfor %}
+            </colgroup>
             <thead class="govuk-table__head dl-table__head">
                 <tr class="govuk-table__row">
                     {% for column in params.columns %}

--- a/src/views/error.html
+++ b/src/views/error.html
@@ -1,19 +1,8 @@
-{% from 'govuk/components/back-link/macro.njk' import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageName = "Error" %}
 
 {% extends "layouts/main.html" %}
-
-{% block beforeContent %}
-    {% if options.lastPage %}
-        {{ govukBackLink({
-            text: options.backLinkText | default("Back"),
-            href: options.lastPage
-        }) }}
-    {% endif %}
-{% endblock %}
-
 {% block content %}
     <h1 class="govuk-heading-xl">Error</h1>
 

--- a/src/views/error.html
+++ b/src/views/error.html
@@ -1,9 +1,18 @@
-
+{% from 'govuk/components/back-link/macro.njk' import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageName = "Error" %}
 
 {% extends "layouts/main.html" %}
+
+{% block beforeContent %}
+    {% if options.lastPage %}
+        {{ govukBackLink({
+            text: options.backLinkText | default("Back"),
+            href: options.lastPage
+        }) }}
+    {% endif %}
+{% endblock %}
 
 {% block content %}
     <h1 class="govuk-heading-xl">Error</h1>

--- a/test/PageObjectModels/resultsPage.js
+++ b/test/PageObjectModels/resultsPage.js
@@ -39,10 +39,10 @@ export default class ResultsPage extends BasePage {
     // Check if there's a table
     expect(await this.page.locator('table').isVisible())
 
-    await this.page.waitForSelector('.govuk-list.govuk-list--bullet')
+    await this.page.waitForSelector('.govuk-error-summary .govuk-list')
     // Get the text content of the bullet points
     const summarytext = await this.page.evaluate(() => {
-      const bulletPoints = Array.from(document.querySelectorAll('.govuk-list.govuk-list--bullet li'))
+      const bulletPoints = Array.from(document.querySelectorAll('.govuk-error-summary .govuk-list li'))
       return bulletPoints.map(li => li.textContent.trim())
     })
 

--- a/test/integration/test_recieving_results.playwright.test.js
+++ b/test/integration/test_recieving_results.playwright.test.js
@@ -40,10 +40,8 @@ test('receiving a result with errors', async ({ page }) => {
   await resultsPage.navigateToRequest('complete-errors')
   await resultsPage.expectPageIsErrorsPage()
 
-  await page.getByText('1 geometry must be in Well-Known Text (WKT) format 1 documentation URL must be').click()
-
   for (const error of errorResponse.response.data['error-summary']) {
-    await expect(page.locator('.govuk-list')).toContainText(error)
+    await expect(page.locator('ul.govuk-list')).toContainText(error)
   }
 
   const tableValues = await getTableContents(page, 'govuk-table')

--- a/test/unit/errorsPage.test.js
+++ b/test/unit/errorsPage.test.js
@@ -37,6 +37,13 @@ describe('errors page', () => {
       limit: 50
     }
 
+    const summaryItem = (errorMessage) => {
+      return {
+        text: errorMessage,
+        href: ''
+      }
+    }
+
     const params = {
       options: {
         tableParams: {
@@ -45,7 +52,7 @@ describe('errors page', () => {
           fields: responseDetails.getFields()
         },
         requestParams: requestData.getParams(),
-        errorSummary: requestData.getErrorSummary(),
+        errorSummary: requestData.getErrorSummary().map(summaryItem),
         mappings: responseDetails.getFieldMappings(),
         verboseRows: responseDetails.getRowsWithVerboseColumns(),
         pagination: responseDetails.getPagination(0)
@@ -64,7 +71,7 @@ describe('errors page', () => {
     expect(errorItems.length).toEqual(6)
 
     params.options.errorSummary.forEach((message, i) => {
-      expect(errorItems[i].textContent).toContain(message)
+      expect(errorItems[i].textContent).toContain(message.text)
     })
 
     // table

--- a/test/unit/resultsController.test.js
+++ b/test/unit/resultsController.test.js
@@ -136,7 +136,7 @@ describe('ResultsController', () => {
         },
         datasetName: req.sessionModel.get('dataset'),
 
-        errorSummary: ['error summary'],
+        errorSummary: [{ text: 'error summary', href: '' }],
         mappings: { fields: 'geometries' },
         geometries: ['geometries'],
         pagination: 'pagination',

--- a/test/unit/resultsController.test.js
+++ b/test/unit/resultsController.test.js
@@ -142,7 +142,8 @@ describe('ResultsController', () => {
         pagination: 'pagination',
         requestParams: 'params',
         template: 'results/no-errors',
-        id: req.params.id
+        id: req.params.id,
+        lastPage: `/check/status/${req.params.id}`
       })
     })
 


### PR DESCRIPTION
## What type of PR is this? 

- [x] Feature

## Description

Update content & design elements of the check tool's "you've got errors" page.

## Related Tickets & Documents

- Issue #571 
- Followup to #610 

## QA Instructions, Screenshots, Recordings

For cases where the LPA name is not available (e.g. we have not arrived via deep link) the text at the bottom defaults to "How to improve the data".

<img width="992" alt="image" src="https://github.com/user-attachments/assets/5cefadf6-5857-4218-b9c2-31e2de2e2d32">

But when the accessing the check tool via a deep link we can see the LPA's name:

<img width="1033" alt="image" src="https://github.com/user-attachments/assets/64a461ed-f4a9-4e57-b03f-5db7ba2c51ad">


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced error summary presentation with a structured format, improving clarity for users.
  - Updated button text from "Upload a new version" to "Check your data" to better reflect functionality.
  - Introduced guidance for users on improving data quality with actionable steps.
  - Added a back navigation option on the status page for improved user experience.
  - Implemented functionality to track the last page visited by users.
  - Added a new back link on the confirmation page for easier navigation.
  - Streamlined map display in the no-errors template for clearer information presentation.
  - Improved readability of dataset names in the dataset banner.

- **Bug Fixes**
  - Improved error message handling to ensure accurate display and processing of error summaries.

- **Documentation**
  - Added JSDoc comments for methods to clarify functionality and expected outputs.

- **Tests**
  - Refined test cases to validate the new error summary structure and ensure robust error handling.
  - Updated tests to reflect changes in error handling and template structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->