### PR TITLE
segment datasets into mandated and ODP on org overview page

### DIFF
--- a/src/middleware/overview.middleware.js
+++ b/src/middleware/overview.middleware.js
@@ -37,7 +37,7 @@ const fetchLatestResources = fetchMany({
 
 const fetchProvisions = fetchMany({
   query: ({ params }) => {
-    const excludeDatasets = config.datasetsFilter.map(dataset => `'${dataset}'`).join(',')
+    const excludeDatasets = Object.keys(config.datasetsConfig).map(dataset => `'${dataset}'`).join(',')
     return /* sql */ `select dataset, project, provision_reason 
        from provision where organisation = '${params.lpa}' and dataset in (${excludeDatasets})`
   },

--- a/src/middleware/overview.middleware.js
+++ b/src/middleware/overview.middleware.js
@@ -118,7 +118,7 @@ const orgStatsReducer = (accumulator, dataset) => {
 
 /**
  *
- * @param {{ provisions: { dataset: string, provision_reason: string}[], lpaOverview: Object, orgInfo: Object }} req
+ * @param {{ provisions: { dataset: string, provision_reason: string, project: string }[], lpaOverview: Object, orgInfo: Object }} req
  * @param res
  * @param next
  */
@@ -140,20 +140,21 @@ export function prepareOverviewTemplateParams (req, res, next) {
     }
   })
 
-  // re-sort the datasets to be in alphabetical order
-  datasets.sort((a, b) => a.slug.localeCompare(b.slug))
-
   const totalDatasets = datasets.length
   const [datasetsWithEndpoints, datasetsWithIssues, datasetsWithErrors] =
       datasets.reduce(orgStatsReducer, [0, 0, 0])
 
   const provisionData = new Map()
   for (const provision of provisions ?? []) {
-    provisionData.set(provision.dataset, provision.provision_reason)
+    provisionData.set(provision.dataset, provision)
+  }
+
+  for (const dataset of datasets) {
+    dataset.project = provisionData.get(dataset.slug)?.project
   }
 
   const datasetsByReason = _.groupBy(datasets, (ds) => {
-    const reason = provisionData.get(ds.slug)
+    const reason = provisionData.get(ds.slug)?.provision_reason
     switch (reason) {
       case 'statutory':
         return 'statutory'

--- a/src/middleware/overview.middleware.js
+++ b/src/middleware/overview.middleware.js
@@ -35,6 +35,15 @@ const fetchLatestResources = fetchMany({
   dataset: FetchOptions.performanceDb
 })
 
+const fetchProvisions = fetchMany({
+  query: ({ params }) => {
+    const excludeDatasets = config.datasetsFilter.map(dataset => `'${dataset}'`).join(',')
+    return /* sql */ `select dataset, project, provision_reason 
+       from provision where organisation = '${params.lpa}' and dataset in (${excludeDatasets})`
+  },
+  result: 'provisions'
+})
+
 /**
  * Updates req with `entityCounts` (of shape `{ resource, dataset}|{ resource, dataset, entityCount }`)
  *
@@ -57,7 +66,7 @@ const statusOrdering = new Map(['Live', 'Needs fixing', 'Error', 'Not submitted'
 
 /**
  * The overview data can contain multiple rows per dataset,
- * and we want a collection of with one item per dataset,
+ * and we want a collection of one item per dataset,
  * because that's how we display it on the page.
  *
  * @param {object[]} lpaOverview
@@ -107,8 +116,14 @@ const orgStatsReducer = (accumulator, dataset) => {
   return accumulator
 }
 
+/**
+ *
+ * @param {{ provisions: { dataset: string, provision_reason: string}[], lpaOverview: Object, orgInfo: Object }} req
+ * @param res
+ * @param next
+ */
 export function prepareOverviewTemplateParams (req, res, next) {
-  const { lpaOverview, orgInfo: organisation } = req
+  const { lpaOverview, orgInfo: organisation, provisions } = req
   const datasets = aggregateOverviewData(lpaOverview)
   // add in any of the missing key 8 datasets
   const keys = new Set(datasets.map(d => d.slug))
@@ -132,9 +147,28 @@ export function prepareOverviewTemplateParams (req, res, next) {
   const [datasetsWithEndpoints, datasetsWithIssues, datasetsWithErrors] =
       datasets.reduce(orgStatsReducer, [0, 0, 0])
 
+  const provisionData = new Map()
+  for (const provision of provisions ?? []) {
+    provisionData.set(provision.dataset, provision.provision_reason)
+  }
+
+  const datasetsByReason = _.groupBy(datasets, (ds) => {
+    const reason = provisionData.get(ds.slug)
+    switch (reason) {
+      case 'statutory':
+        return 'statutory'
+      default:
+        return 'other'
+    }
+  })
+
+  for (const coll of Object.values(datasetsByReason)) {
+    coll.sort((a, b) => a.slug.localeCompare(b.slug))
+  }
+
   req.templateParams = {
     organisation,
-    datasets,
+    datasets: datasetsByReason,
     totalDatasets,
     datasetsWithEndpoints,
     datasetsWithIssues,
@@ -158,6 +192,7 @@ export default [
   fetchLatestResources,
   fetchEntityCounts,
   fetchLpaOverview,
+  fetchProvisions,
   prepareOverviewTemplateParams,
   getOverview,
   logPageError

--- a/src/routes/schemas.js
+++ b/src/routes/schemas.js
@@ -40,21 +40,25 @@ export const datasetStatusEnum = {
 
 const OrgField = v.strictObject({ name: NonEmptyString, organisation: NonEmptyString, statistical_geography: v.optional(v.string()), entity: v.optional(v.integer()) })
 const DatasetNameField = v.strictObject({ name: NonEmptyString, dataset: NonEmptyString, collection: NonEmptyString })
+const DatasetItem = v.strictObject({
+  endpoint: v.optional(v.url()),
+  status: v.enum(datasetStatusEnum),
+  slug: NonEmptyString,
+  issue_count: v.optional(v.number()),
+  error: v.optional(v.nullable(NonEmptyString)),
+  http_error: v.optional(NonEmptyString),
+  issue: v.optional(NonEmptyString),
+  entity_count: v.optional(v.number()),
+  // synthetic entry, represents a user friendly count (e.g. count missing value in a column as 1 issue)
+  numIssues: v.optional(v.number())
+})
 
 export const OrgOverviewPage = v.strictObject({
   organisation: OrgField,
-  datasets: v.array(v.strictObject({
-    endpoint: v.optional(v.url()),
-    status: v.enum(datasetStatusEnum),
-    slug: NonEmptyString,
-    issue_count: v.optional(v.number()),
-    error: v.optional(v.nullable(NonEmptyString)),
-    http_error: v.optional(NonEmptyString),
-    issue: v.optional(NonEmptyString),
-    entity_count: v.optional(v.number()),
-    // synthetic entry, represents a user friendly count (e.g. count missing value in a column as 1 issue)
-    numIssues: v.optional(v.number())
-  })),
+  datasets: v.object({
+    statutory: v.optional(v.array(DatasetItem)),
+    other: v.optional(v.array(DatasetItem))
+  }),
   totalDatasets: v.integer(),
   datasetsWithEndpoints: v.integer(),
   datasetsWithIssues: v.integer(),

--- a/src/routes/schemas.js
+++ b/src/routes/schemas.js
@@ -89,6 +89,7 @@ const DatasetItem = v.strictObject({
   http_error: v.optional(NonEmptyString),
   issue: v.optional(NonEmptyString),
   entity_count: v.optional(v.number()),
+  project: v.optional(v.string()),
   // synthetic entry, represents a user friendly count (e.g. count missing value in a column as 1 issue)
   numIssues: v.optional(v.number())
 })
@@ -128,7 +129,7 @@ export const OrgDatasetOverview = v.strictObject({
       documentation_url: v.optional(v.string()),
       endpoint: v.string(),
       lastAccessed: v.string(),
-      lastUpdated: v.string(),
+      lastUpdated: v.nullable(v.string()),
       error: v.optional(v.strictObject({
         code: v.integer(),
         exception: v.string()

--- a/src/views/organisations/overview.html
+++ b/src/views/organisations/overview.html
@@ -114,7 +114,11 @@
 
   {% if datasets.other.length > 0 %}
   <h2 class="govuk-heading-m">Datasets organisations in Open Digital Planning programme must provide</h2>
-  <p>{{ organisation.name}} is a member of the Open Digital Planning programme.</p>
+    {% if datasets.other[0].project === 'open-digital-planning' %}
+      <p class="org-membership-info">{{ organisation.name}} is a member of the Open Digital Planning programme.</p>
+    {% else %}
+      <p class="org-membership-info">{{ organisation.name}} is not a member of the Open Digital Planning programme.</p>
+    {% endif %}
   <ul class="govuk-task-list" data-reason="other">
 
     {% for dataset in datasets.other %}

--- a/src/views/organisations/overview.html
+++ b/src/views/organisations/overview.html
@@ -6,6 +6,45 @@
 {% set pageName = organisation.name + " overview" %}
 {% set serviceType = 'Manage' %}
 
+{% macro datasetItem(dataset) %}
+<li class="govuk-task-list__item govuk-task-list__item--with-link" data-dataset="{{ dataset.slug }}">
+  <div class="govuk-task-list__name-and-hint">
+    <h2 class="govuk-heading-m">
+      {% if dataset.status == 'Not submitted' %}
+      <a class="govuk-link govuk-task-list__link"
+         href="/organisations/{{ organisation.organisation }}/{{dataset.slug}}/get-started">
+        {{dataset.slug | datasetSlugToReadableName}}
+      </a>
+      {% else %}
+      <a class="govuk-link govuk-task-list__link"
+         href="/organisations/{{ organisation.organisation }}/{{dataset.slug}}/overview">
+        {{dataset.slug | datasetSlugToReadableName}}
+      </a>
+      {% endif %}
+    </h2>
+    <div class="govuk-task-list__hint">
+      {% if dataset.status == 'Not submitted' %}
+      <p>Data URL not submitted</p>
+      {% elif dataset.status == 'Error' %}
+      <p>{{dataset.error}}</p>
+      {% elif dataset.status == 'Needs fixing' %}
+      <p>There {{ "is" | pluralise(dataset.issue_count) }} {{ dataset.issue_count }} {{ "issue" | pluralise(dataset.issue_count) }} in this dataset</p>
+      {% else %}
+      <p>Data URL submitted</p>
+      {% endif %}
+
+    </div>
+  </div>
+
+  <div class="govuk-task-list__status">
+    {{govukTag({
+    text: dataset.status,
+    classes: dataset.status | statusToTagClass
+    })}}
+  </div>
+</li>
+{% endmacro %}
+
 {% block beforeContent %}
 {{ super() }}
 
@@ -62,49 +101,29 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h2 class="govuk-heading-m">Datasets</h2>
-    <ul class="govuk-task-list">
 
-      {% for dataset in datasets %}
-        <li class="govuk-task-list__item govuk-task-list__item--with-link">
-          <div class="govuk-task-list__name-and-hint">
-            <h2 class="govuk-heading-m">
-              {% if dataset.status == 'Not submitted' %}
-                <a class="govuk-link govuk-task-list__link"
-                  href="/organisations/{{ organisation.organisation }}/{{dataset.slug}}/get-started">
-                  {{dataset.slug | datasetSlugToReadableName}}
-                </a>
-              {% else %}
-                <a class="govuk-link govuk-task-list__link"
-                  href="/organisations/{{ organisation.organisation }}/{{dataset.slug}}/overview">
-                  {{dataset.slug | datasetSlugToReadableName}}
-                </a>
-              {% endif %}
-            </h2>
-            <div class="govuk-task-list__hint">
-              {% if dataset.status == 'Not submitted' %}
-                <p>Data URL not submitted</p>
-              {% elif dataset.status == 'Error' %}
-                <p>{{dataset.error}}</p>
-              {% elif dataset.status == 'Needs fixing' %}
-                <p>There {{ "is" | pluralise(dataset.issue_count) }} {{ dataset.issue_count }} {{ "issue" | pluralise(dataset.issue_count) }} in this dataset</p>
-              {% else %}
-                <p>Data URL submitted</p>
-              {% endif %}
+  {% if datasets.statutory.length > 0 %}
+    <h2 class="govuk-heading-m">Datasets {{ organisation.name }} must provide</h2>
+    <ul class="govuk-task-list govuk-!-margin-bottom-8" data-reason="statutory">
 
-            </div>
-          </div>
-
-          <div class="govuk-task-list__status">
-            {{govukTag({
-              text: dataset.status,
-              classes: dataset.status | statusToTagClass
-            })}}
-          </div>
-        </li>
+      {% for dataset in datasets.statutory %}
+        {{ datasetItem(dataset) }}
       {% endfor %}
-
     </ul>
+  {% endif %}
+
+  {% if datasets.other.length > 0 %}
+  <h2 class="govuk-heading-m">Datasets organisations in Open Digital Planning programme must provide</h2>
+  <p>{{ organisation.name}} is a member of the Open Digital Planning programme.</p>
+  <ul class="govuk-task-list" data-reason="other">
+
+    {% for dataset in datasets.other %}
+      {{ datasetItem(dataset) }}
+    {% endfor %}
+  </ul>
+  {% endif %}
+
+
   </div>
 </div>
 

--- a/test/unit/lpaOverviewPage.test.js
+++ b/test/unit/lpaOverviewPage.test.js
@@ -71,7 +71,7 @@ describe(`LPA Overview Page (seed: ${seed})`, () => {
       datasetGroup({ expect }, 'other', params.datasets.other, document)
 
       const infoText = document.querySelector('.org-membership-info').textContent
-      expect(infoText).match(/.* is (a|not a) member of .*/)
+      expect(infoText).match(new RegExp(`${params.organisation.name} is (a|not a) member of .*`))
     }
   })
 

--- a/test/unit/lpaOverviewPage.test.js
+++ b/test/unit/lpaOverviewPage.test.js
@@ -11,8 +11,29 @@ const nunjucks = setupNunjucks({ datasetNameMapping })
 
 const seed = new Date().getTime()
 
+/**
+ * Verifies the number of rendered dataset cards for group designated by `key`
+ * matches the number of datasets passed to the template.
+ *
+ * @param { Function } expect
+ * @param {string} key
+ * @param {{ slug: string }[]} datasets
+ * @param {Document} document
+ */
+const datasetGroup = ({ expect }, key, datasets, document) => {
+  const datasetCards = document.querySelectorAll(`ul[data-reason="${key}"] li`)
+  expect(datasetCards.length).toEqual(datasets.length)
+  const datasetSlugToReadableName = makeDatasetSlugToReadableNameFilter(datasetNameMapping)
+
+  datasets.forEach((dataset, i) => {
+    expect(datasetCards[i].querySelector('.govuk-heading-m').textContent).toContain(datasetSlugToReadableName(dataset.slug))
+  })
+}
+
 describe(`LPA Overview Page (seed: ${seed})`, () => {
   const params = mocker(OrgOverviewPage, seed)
+  console.debug(`mocked datasets: statutory = ${params.datasets.statutory?.length ?? 'none'}, other = ${params.datasets.other?.length ?? 'none'}`)
+
   const html = nunjucks.render('organisations/overview.html', params)
 
   const dom = new jsdom.JSDOM(html)
@@ -39,18 +60,20 @@ describe(`LPA Overview Page (seed: ${seed})`, () => {
     expect(statsBoxes[2].textContent).toContain('datasets need fixing')
   })
 
-  const datasetCards = document.querySelector('.govuk-task-list').children
-  it('The correct number of dataset cards are rendered with the correct titles', () => {
-    expect(datasetCards.length).toEqual(params.datasets.length)
-
-    const datasetSlugToReadableName = makeDatasetSlugToReadableNameFilter(datasetNameMapping)
-
-    params.datasets.forEach((dataset, i) => {
-      expect(datasetCards[i].querySelector('.govuk-heading-m').textContent).toContain(datasetSlugToReadableName(dataset.slug))
-    })
+  it('The correct number of dataset cards are rendered with the correct titles in group "statutory"', () => {
+    if (params.datasets.statutory) {
+      datasetGroup({ expect }, 'statutory', params.datasets.statutory, document)
+    }
   })
 
-  params.datasets.forEach((dataset, i) => {
+  it('The correct number of dataset cards are rendered with the correct titles in group "other"', () => {
+    if (params.datasets.other) {
+      datasetGroup({ expect }, 'other', params.datasets.other, document)
+    }
+  })
+
+  const allDatasets = [].concat(...Object.values(params.datasets.statutory ?? []), ...Object.values(params.datasets.other ?? []))
+  allDatasets.forEach((dataset, i) => {
     it(`dataset cards are rendered with correct hints for dataset='${dataset.slug}'`, () => {
       let expectedHint = 'Data URL submitted'
       if (dataset.status === 'Not submitted') {
@@ -66,13 +89,13 @@ describe(`LPA Overview Page (seed: ${seed})`, () => {
       } else if (dataset.status === 'Error' && dataset.issue_count > 1) {
         expectedHint = `There are ${dataset.issue_count} issues in this dataset`
       }
-
-      expect(datasetCards[i].querySelector('.govuk-task-list__hint').textContent.trim()).toContain(expectedHint)
+      const datasetCard = document.querySelector(`[data-dataset="${dataset.slug}"]`)
+      expect(datasetCard.querySelector('.govuk-task-list__hint').textContent.trim()).toContain(expectedHint)
     })
   })
 
   it('Renders the correct actions on each dataset card', () => {
-    params.datasets.forEach((dataset, i) => {
+    allDatasets.forEach((dataset, i) => {
       const expectedActions = []
       if (!dataset.endpoint) {
         expectedActions.push({ text: 'Add endpoint', href: '/taskLists/taskChecklist' })
@@ -88,7 +111,8 @@ describe(`LPA Overview Page (seed: ${seed})`, () => {
     })
   })
 
-  params.datasets.forEach((dataset, i) => {
+  const datasetCards = document.querySelectorAll('li[data-dataset]:not([data-dataset=""])')
+  allDatasets.forEach((dataset, i) => {
     it(`Renders the correct status on each dataset card for dataset='${dataset.slug}'`, () => {
       if (!(dataset.status in datasetStatusEnum)) {
         throw new Error(`Unknown dataset status: ${dataset.status}`)

--- a/test/unit/lpaOverviewPage.test.js
+++ b/test/unit/lpaOverviewPage.test.js
@@ -69,6 +69,9 @@ describe(`LPA Overview Page (seed: ${seed})`, () => {
   it('The correct number of dataset cards are rendered with the correct titles in group "other"', () => {
     if (params.datasets.other) {
       datasetGroup({ expect }, 'other', params.datasets.other, document)
+
+      const infoText = document.querySelector('.org-membership-info').textContent
+      expect(infoText).match(/.* is (a|not a) member of .*/)
     }
   })
 

--- a/test/unit/middleware/overview.middleware.test.js
+++ b/test/unit/middleware/overview.middleware.test.js
@@ -38,11 +38,11 @@ describe('overview.middleware', () => {
         organisation: { name: 'Example LPA', organisation: 'LPA' },
         datasets: {
           statutory: expect.arrayContaining([
-            { endpoint: 'https://example.com', status: 'Live', slug: 'dataset1', error: undefined, issue_count: 0 },
-            { endpoint: 'https://example.com', status: 'Error', slug: 'dataset3', error: undefined, issue_count: 0 }
+            { endpoint: 'https://example.com', status: 'Live', slug: 'dataset1', error: undefined, issue_count: 0, project: 'open-digital-planning' },
+            { endpoint: 'https://example.com', status: 'Error', slug: 'dataset3', error: undefined, issue_count: 0, project: 'open-digital-planning' }
           ]),
           other: expect.arrayContaining([
-            { endpoint: null, status: 'Needs fixing', slug: 'dataset2', error: undefined, issue_count: 0 }
+            { endpoint: null, status: 'Needs fixing', slug: 'dataset2', error: undefined, issue_count: 0, project: 'open-digital-planning' }
           ])
         },
         totalDatasets: 3,

--- a/test/unit/middleware/overview.middleware.test.js
+++ b/test/unit/middleware/overview.middleware.test.js
@@ -31,11 +31,13 @@ describe('overview.middleware', () => {
 
       const expectedTemplateParams = {
         organisation: { name: 'Example LPA', organisation: 'LPA' },
-        datasets: expect.arrayContaining([
-          { endpoint: 'https://example.com', status: 'Live', slug: 'dataset1', error: undefined, issue_count: 0 },
-          { endpoint: null, status: 'Needs fixing', slug: 'dataset2', error: undefined, issue_count: 0 },
-          { endpoint: 'https://example.com', status: 'Error', slug: 'dataset3', error: undefined, issue_count: 0 }
-        ]),
+        datasets: {
+          other: expect.arrayContaining([
+            { endpoint: 'https://example.com', status: 'Live', slug: 'dataset1', error: undefined, issue_count: 0 },
+            { endpoint: null, status: 'Needs fixing', slug: 'dataset2', error: undefined, issue_count: 0 },
+            { endpoint: 'https://example.com', status: 'Error', slug: 'dataset3', error: undefined, issue_count: 0 }
+          ])
+        },
         totalDatasets: 3,
         datasetsWithEndpoints: 2,
         datasetsWithIssues: 1,
@@ -110,11 +112,13 @@ describe('overview.middleware', () => {
 
       req.templateParams = {
         organisation: { name: 'Example LPA', organisation: 'LPA' },
-        datasets: [
-          { endpoint: 'https://example.com', status: 'Live', slug: 'dataset1' },
-          { endpoint: null, status: 'Needs fixing', slug: 'dataset2' },
-          { endpoint: 'https://example.com', status: 'Error', slug: 'dataset3' }
-        ],
+        datasets: {
+          other: [
+            { endpoint: 'https://example.com', status: 'Live', slug: 'dataset1' },
+            { endpoint: null, status: 'Needs fixing', slug: 'dataset2' },
+            { endpoint: 'https://example.com', status: 'Error', slug: 'dataset3' }
+          ]
+        },
         totalDatasets: 3,
         datasetsWithEndpoints: 2,
         datasetsWithIssues: 1,

--- a/test/unit/middleware/overview.middleware.test.js
+++ b/test/unit/middleware/overview.middleware.test.js
@@ -24,9 +24,9 @@ describe('overview.middleware', () => {
         params: { lpa: 'LPA' },
         orgInfo: exampleLpa,
         provisions: [
-          { dataset: 'dataset1', provision_reason: 'statutory' },
-          { dataset: 'dataset2', provision_reason: 'expected' },
-          { dataset: 'dataset3', provision_reason: 'statutory' }
+          { dataset: 'dataset1', provision_reason: 'statutory', project: 'open-digital-planning' },
+          { dataset: 'dataset2', provision_reason: 'expected', project: 'open-digital-planning' },
+          { dataset: 'dataset3', provision_reason: 'statutory', project: 'open-digital-planning' }
         ],
         lpaOverview: perfDbApiResponse
       }

--- a/test/unit/middleware/overview.middleware.test.js
+++ b/test/unit/middleware/overview.middleware.test.js
@@ -23,6 +23,11 @@ describe('overview.middleware', () => {
       const req = {
         params: { lpa: 'LPA' },
         orgInfo: exampleLpa,
+        provisions: [
+          { dataset: 'dataset1', provision_reason: 'statutory' },
+          { dataset: 'dataset2', provision_reason: 'expected' },
+          { dataset: 'dataset3', provision_reason: 'statutory' }
+        ],
         lpaOverview: perfDbApiResponse
       }
       const res = { render: vi.fn() }
@@ -32,10 +37,12 @@ describe('overview.middleware', () => {
       const expectedTemplateParams = {
         organisation: { name: 'Example LPA', organisation: 'LPA' },
         datasets: {
-          other: expect.arrayContaining([
+          statutory: expect.arrayContaining([
             { endpoint: 'https://example.com', status: 'Live', slug: 'dataset1', error: undefined, issue_count: 0 },
-            { endpoint: null, status: 'Needs fixing', slug: 'dataset2', error: undefined, issue_count: 0 },
             { endpoint: 'https://example.com', status: 'Error', slug: 'dataset3', error: undefined, issue_count: 0 }
+          ]),
+          other: expect.arrayContaining([
+            { endpoint: null, status: 'Needs fixing', slug: 'dataset2', error: undefined, issue_count: 0 }
           ])
         },
         totalDatasets: 3,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

The datasets on organisations' overview pages are now grouped into two groups:
- mandatory datasets
- datasets covered by ODP

Where a particular dataset falls is done by looking up values in the `provision` table. 

### Summary of changes

- Changed the `OrgOverviewPage` schema `datasets` property to be a an object with (potentially) two fields, one for each group we currently support: `statutory` and `other`.
- fetch data from the `provision` table to group datasets
- updated the `organisations/overview` template, datasets are now grouped under two different headings (as in design)
	- extracted the list item into a macro
	- added `data-reason` and `data-dataset` attributes to make testing easier.

## Related Tickets & Documents

- Closes #618 

## QA Instructions, Screenshots, Recordings

Go to any LPA's page and compare with design in #618, e.g. [here](https://submit-pr-645.herokuapp.com/organisations/local-authority:LBH)

![image](https://github.com/user-attachments/assets/123477a5-9322-45a8-9dff-ef9a1fa84e46)


## Added/updated tests?

- [x] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new middleware function to fetch and process provisions data.
  - Added a new schema for `DatasetItem`, enhancing dataset representation.
  - Implemented a new macro for rendering dataset items, improving code organisation.

- **Bug Fixes**
  - Updated tests to reflect changes in dataset structure, ensuring accuracy in rendering.

- **Tests**
  - Added new helper functions and test cases for improved validation of dataset groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->