### PR TITLE
express error handling

### DIFF
--- a/src/middleware/issueDetails.middleware.js
+++ b/src/middleware/issueDetails.middleware.js
@@ -13,9 +13,6 @@ import {
 import { fetchIf, fetchMany, fetchOne, FetchOptions, handleRejections, renderTemplate } from './middleware.builders.js'
 import * as v from 'valibot'
 import { pagination } from '../utils/pagination.js'
-import logger from '../utils/logger.js'
-import { types } from '../utils/logging.js'
-import axios from 'axios'
 
 export const IssueDetailsQueryParams = v.object({
   lpa: v.string(),

--- a/src/middleware/issueDetails.middleware.js
+++ b/src/middleware/issueDetails.middleware.js
@@ -33,7 +33,7 @@ const validateIssueDetailsQueryParams = validateQueryParams({
  * Requires resource id under `req.resource.resource`.
  */
 const fetchIssues = fetchMany({
-  query: performanceDbApi.getIssuesQuery,
+  query: ({ req }) => performanceDbApi.getIssuesQuery(req),
   result: 'issues',
   dataset: FetchOptions.fromParams
 })
@@ -102,7 +102,7 @@ async function fetchEntry (req, res, next) {
  * Middleware. Updates `req` with `issueEntitiesCount` which is the count of entities that have issues.
  */
 const fetchIssueEntitiesCount = fetchOne({
-  query: performanceDbApi.getEntitiesWithIssuesCountQuery,
+  query: ({ req }) => performanceDbApi.getEntitiesWithIssuesCountQuery(req),
   result: 'issueEntitiesCount',
   dataset: FetchOptions.fromParams
 })
@@ -173,7 +173,8 @@ const processEntryRow = (issueType, issuesByEntryNumber, row) => {
  * Middleware. Updates req with `templateParams`
  */
 export function prepareIssueDetailsTemplateParams (req, res, next) {
-  const { entryData, issueEntitiesCount, issuesByEntryNumber, entryNumberCount, entityCount: entityCountRow } = req
+  const { entryData, issueEntitiesCount: issueEntitiesCountObj, issuesByEntryNumber, entryNumberCount, entityCount: entityCountRow } = req
+  const { count: issueEntitiesCount } = issueEntitiesCountObj
   const { lpa, dataset: datasetId, issue_type: issueType, issue_field: issueField } = req.params
   const { pageNumber } = req.parsedParams
   const { entity_count: entityCount } = entityCountRow ?? { entity_count: 0 }
@@ -279,7 +280,7 @@ export const getIssueDetails = renderTemplate({
 
 /* eslint-disable no-return-assign */
 const zeroEntityCount = (req) => req.entityCount = { entity_count: 0 }
-const zeroIssueEntitiesCount = (req) => req.issueEntitiesCount = 0
+const zeroIssueEntitiesCount = (req) => req.issueEntitiesCount = { count: 0 }
 const emptyIssuesCollection = (req) => req.issues = []
 
 export default [

--- a/src/middleware/issueDetails.middleware.js
+++ b/src/middleware/issueDetails.middleware.js
@@ -1,4 +1,4 @@
-import performanceDbApi from '../services/performanceDbApi.js'
+import performanceDbApi, { issuesQueryLimit } from '../services/performanceDbApi.js'
 import {
   fetchDatasetInfo,
   fetchEntityCount,
@@ -10,11 +10,12 @@ import {
   validateQueryParams,
   getIsPageNumberInRange
 } from './common.middleware.js'
-import { fetchIf, renderTemplate } from './middleware.builders.js'
+import { fetchIf, fetchMany, fetchOne, FetchOptions, handleRejections, renderTemplate } from './middleware.builders.js'
 import * as v from 'valibot'
 import { pagination } from '../utils/pagination.js'
 import logger from '../utils/logger.js'
 import { types } from '../utils/logging.js'
+import axios from 'axios'
 
 export const IssueDetailsQueryParams = v.object({
   lpa: v.string(),
@@ -29,32 +30,16 @@ const validateIssueDetailsQueryParams = validateQueryParams({
   schema: IssueDetailsQueryParams
 })
 
-const issuesQueryLimit = 1000
-
 /**
- *
  * Middleware. Updates `req` with `issues`.
  *
  * Requires resource id under `req.resource.resource`.
- *
- * @param {*} req
- * @param {*} res
- * @param {*} next
  */
-async function fetchIssues (req, res, next) {
-  const { dataset: datasetId, issue_type: issueType, issue_field: issueField } = req.params
-  const { pageNumber } = req.parsedParams
-  const resourceId = req.resource.resource
-  const offset = Math.floor((pageNumber - 1) / issuesQueryLimit) * issuesQueryLimit
-  logger.debug('fetchIssues()', { type: types.App, resourceId, issueType, issueField, offset })
-  try {
-    const issues = await performanceDbApi.getIssues({ resource: resourceId, issueType, issueField, offset }, datasetId)
-    req.issues = issues
-    next()
-  } catch (error) {
-    next(error)
-  }
-}
+const fetchIssues = fetchMany({
+  query: performanceDbApi.getIssuesQuery,
+  result: 'issues',
+  dataset: FetchOptions.fromParams
+})
 
 /**
  *
@@ -117,22 +102,13 @@ async function fetchEntry (req, res, next) {
 }
 
 /**
- *
  * Middleware. Updates `req` with `issueEntitiesCount` which is the count of entities that have issues.
- *
- * Requires `req.resource.resource`
- *
- * @param {*} req
- * @param {*} res
- * @param {*} next
  */
-async function fetchIssueEntitiesCount (req, res, next) {
-  const { dataset: datasetId, issue_type: issueType, issue_field: issueField } = req.params
-  const { resource: resourceId } = req.resource
-  const issueEntitiesCount = await performanceDbApi.getEntitiesWithIssuesCount({ resource: resourceId, issueType, issueField }, datasetId)
-  req.issueEntitiesCount = issueEntitiesCount
-  next()
-}
+const fetchIssueEntitiesCount = fetchOne({
+  query: performanceDbApi.getEntitiesWithIssuesCountQuery,
+  result: 'issueEntitiesCount',
+  dataset: FetchOptions.fromParams
+})
 
 /**
  *
@@ -318,7 +294,7 @@ export default [
   reformatIssuesToBeByEntryNumber,
   fetchIf(isResourceDataPresent, fetchIssueEntitiesCount, zeroIssueEntitiesCount),
   getIsPageNumberInRange('issueEntitiesCount'),
-  fetchEntry,
+  handleRejections(fetchEntry),
   fetchIf(isResourceDataPresent, fetchEntityCount, zeroEntityCount),
   prepareIssueDetailsTemplateParams,
   getIssueDetails,

--- a/src/middleware/middleware.builders.js
+++ b/src/middleware/middleware.builders.js
@@ -290,13 +290,12 @@ export const onlyIf = (condition, middlewareFn) => {
   }
 }
 
-async function safeFn (req, res, next) {
-  const [_, err] = await this.middleware(req, res, next).then(val => [val, undefined]).catch(err => [undefined, err])
-  if (err) {
-    return next(err)
+async function safeFn(req, res, next) {
+  try {
+    await this.middleware(req, res, next)
+  } catch (err) {
+    next(err)
   }
-
-  return next()
 }
 
 /**

--- a/src/middleware/middleware.builders.js
+++ b/src/middleware/middleware.builders.js
@@ -290,7 +290,7 @@ export const onlyIf = (condition, middlewareFn) => {
   }
 }
 
-async function safeFn(req, res, next) {
+async function safeFn (req, res, next) {
   try {
     await this.middleware(req, res, next)
   } catch (err) {

--- a/src/middleware/middleware.builders.js
+++ b/src/middleware/middleware.builders.js
@@ -289,3 +289,24 @@ export const onlyIf = (condition, middlewareFn) => {
     }
   }
 }
+
+async function safeFn (req, res, next) {
+  const [_, err] = await this.middleware(req, res, next).then(val => [val, undefined]).catch(err => [undefined, err])
+  if (err) {
+    return next(err)
+  }
+
+  return next()
+}
+
+/**
+ * Express 4.x does not handle promise rejections in middleware on its own. The
+ * @{fetchOne} and @{fetchMany} middleware handle that case but for any other async
+ * code you can wrap it in this middleware to ensure rejections don't end up unhandled.
+ *
+ * @param middleware
+ * @returns {any}
+ */
+export const handleRejections = (middleware) => {
+  return safeFn.bind({ middleware })
+}

--- a/src/middleware/overview.middleware.js
+++ b/src/middleware/overview.middleware.js
@@ -1,6 +1,6 @@
 import performanceDbApi, { lpaOverviewQuery } from '../services/performanceDbApi.js'
 import { fetchOrgInfo, logPageError } from './common.middleware.js'
-import { fetchMany, FetchOptions, renderTemplate } from './middleware.builders.js'
+import { fetchMany, FetchOptions, handleRejections, renderTemplate } from './middleware.builders.js'
 import { dataSubjects } from '../utils/utils.js'
 import config from '../../config/index.js'
 import _ from 'lodash'
@@ -156,7 +156,7 @@ export const getOverview = renderTemplate({
 export default [
   fetchOrgInfo,
   fetchLatestResources,
-  fetchEntityCounts,
+  handleRejections(fetchEntityCounts),
   fetchLpaOverview,
   prepareOverviewTemplateParams,
   getOverview,

--- a/src/serverSetup/errorHandlers.js
+++ b/src/serverSetup/errorHandlers.js
@@ -13,6 +13,10 @@ export function setupErrorHandlers (app) {
       errorStack: err.stack
     })
 
+    if (res.headersSent) {
+      return next(err)
+    }
+
     err.template = err.template || (err.status && `errorPages/${err.status}`) || 'errorPages/500'
 
     if (err.redirect) {
@@ -28,6 +32,9 @@ export function setupErrorHandlers (app) {
   })
 
   app.use((req, res, next) => {
+    if (res.headersSent) {
+      return next()
+    }
     logger.info({
       type: types.Response,
       method: req.method,

--- a/src/services/performanceDbApi.js
+++ b/src/services/performanceDbApi.js
@@ -294,7 +294,7 @@ export default {
   },
 
   getEntitiesWithIssuesCountQuery: (req) => {
-    const { dataset: datasetId, issue_type: issueType, issue_field: issueField } = req.params
+    const { issue_type: issueType, issue_field: issueField } = req.params
     const { resource: resourceId } = req.resource
     return /* sql */ `
     SELECT count(DISTINCT entry_number) as count

--- a/src/services/performanceDbApi.js
+++ b/src/services/performanceDbApi.js
@@ -166,6 +166,8 @@ ORDER BY
   rle.name;`
 }
 
+export const issuesQueryLimit = 1000
+
 /**
  * Performance DB API service
  * @export
@@ -284,66 +286,44 @@ export default {
           return { resource, dataset }
         })
     })
-    return (await Promise.allSettled(requests)).map(p => p.value)
+
+    const results = await Promise.allSettled(requests)
+    return results
+      .filter(p => p.status === 'fulfilled')
+      .map(p => p.value)
   },
 
-  /**
-     * Retrieves the count of entities with issues of a specific type and field.
-     *
-     * @param {Object} params - Parameters for the query
-     * @param {string} params.resource - Resource to filter by
-     * @param {string} params.issueType - Issue type to filter by
-     * @param {string} params.issueField - Field to filter by
-     * @param {string} [database="digital-land"] - Database to query (optional)
-     * @returns {Promise<number>} Count of entities with issues
-     */
-  async getEntitiesWithIssuesCount ({
-    resource,
-    issueType,
-    issueField
-  }, database = 'digital-land') {
-    const sql = `
+  getEntitiesWithIssuesCountQuery: (req) => {
+    const { dataset: datasetId, issue_type: issueType, issue_field: issueField } = req.params
+    const { resource: resourceId } = req.resource
+    return /* sql */ `
     SELECT count(DISTINCT entry_number) as count
     FROM issue
-    WHERE resource = '${resource}'
+    WHERE resource = '${resourceId}'
     AND issue_type = '${issueType}'
     AND field = '${issueField}'
   `
-
-    const result = await datasette.runQuery(sql, database)
-
-    return result.formattedData[0].count
   },
 
   /**
-     * Retrieves issues from the performance database.
-     *
-     * @param {Object} params - Object with parameters for the query
-     * @param {string} params.resource - Resource to filter issues by
-     * @param {string} params.issueType - Issue type to filter by
-     * @param {string} params.issueField - Field to filter by
-     * @param {string} [database="digital-land"] - Database to query (defaults to "digital-land")
-     * @returns {Promise<Object>} - Promise resolving to an object with formatted data
-     */
-  async getIssues ({
-    resource,
-    issueType,
-    issueField,
-    offset = 0
-  }, database = 'digital-land') {
-    const sql = `
-    SELECT i.field, i.line_number, entry_number, message, issue_type, value
-    FROM issue i
-    WHERE resource = '${resource}'
-    AND issue_type = '${issueType}'
-    AND field = '${issueField}'
-    ORDER BY entry_number ASC
-    LIMIT 1000 ${offset ? `OFFSET ${offset}` : ''}
-  `
+   *
+   * @param {{ params: { issue_type: string, issue_field: string}, parsedParams: { pageNumber: number}, resource: { resource: string } }} req
+   * @returns {string} sql query
+   */
+  getIssuesQuery: (req) => {
+    const { issue_type: issueType, issue_field: issueField } = req.params
+    const { pageNumber } = req.parsedParams
+    const resourceId = req.resource.resource
+    const offset = Math.floor((pageNumber - 1) / issuesQueryLimit) * issuesQueryLimit
 
-    const result = await datasette.runQuery(sql, database)
-
-    return result.formattedData
+    return /* sql */ `
+      SELECT i.field, i.line_number, entry_number, message, issue_type, value
+      FROM issue i
+      WHERE resource = '${resourceId}'
+      AND issue_type = '${issueType}'
+      AND field = '${issueField}'
+      ORDER BY entry_number ASC
+      LIMIT 1000 ${offset ? `OFFSET ${offset}` : ''}`
   },
 
   /**
@@ -384,24 +364,17 @@ export default {
     return result.formattedData
   },
 
+  /**
+   * Query for the entity count for a given organisation and dataset.
+   *
+   * @param orgEntity
+   * @returns {string}
+   */
   entityCountQuery (orgEntity) {
     return /* sql */ `
       select count(entity) as entity_count
       from entity
       WHERE organisation_entity = '${orgEntity}'
     `
-  },
-
-  /**
-   * Retrieves the entity count for a given organisation and dataset.
-   *
-   * @param {string} orgEntity - The organisation entity to retrieve the entity count for.
-   * @param {string} dataset - The dataset to retrieve the entity count from.
-   * @returns {number} The entity count for the given resource and dataset.
-   */
-  async getEntityCount (orgEntity, dataset) {
-    const query = this.entityCountQuery(orgEntity)
-    const result = await datasette.runQuery(query, dataset)
-    return result.formattedData[0].entity_count
   }
 }

--- a/src/services/performanceDbApi.js
+++ b/src/services/performanceDbApi.js
@@ -184,27 +184,6 @@ export default {
   datasetIssuesQuery,
 
   /**
-     * Retrieves LPA dataset issues for a given resource and dataset ID.
-     *
-     * @param {string} resource - The resource to retrieve issues for.
-     * @param {string} datasetId - The ID of the dataset to retrieve issues for.
-     *
-     * @returns {Promise<object[]>} An array of issue objects, each containing:
-     *   - field: {string} The field associated with the issue.
-     *   - issue_type: {string} The type of issue.
-     *   - line_number: {number} The line number of the issue.
-     *   - value: {string} The value associated with the issue.
-     *   - message: {string} The error message associated with the issue.
-     *   - status: {string} The status of the issue ('Needs fixing' or 'Live').
-     *   - num_issues: {number} The number of issues of this type.
-     */
-  getLpaDatasetIssues: async (resource, datasetId) => {
-    const sql = datasetIssuesQuery(resource, datasetId)
-    const result = await datasette.runQuery(sql)
-    return result.formattedData
-  },
-
-  /**
      * Returns a task message based on the provided issue type, issue count, and entity count.
      *
      * @param {{issue_type: string, num_issues: number, entityCount: number, field: string }} options
@@ -257,20 +236,6 @@ export default {
     LEFT JOIN organisation o ON REPLACE(ro.organisation, '-eng', '') = o.organisation
     WHERE REPLACE(ro.organisation, '-eng', '') = '${lpa}'
     AND rle.pipeline = '${dataset}'`
-  },
-
-  /**
-     * Retrieves the latest resource information for a given LPA and dataset.
-     *
-     * @param {string} lpa - The Local Planning Authority (LPA) identifier.
-     * @param {string} dataset - The dataset to retrieve the latest resource for.
-     * @returns {object} The latest resource information, including the resource, status, endpoint, endpoint URL, days since 200, and exception.
-     */
-  async getLatestResource (lpa, dataset) {
-    const sql = this.latestResourceQuery(lpa, dataset)
-    const result = await datasette.runQuery(sql)
-
-    return result.formattedData[0]
   },
 
   /**

--- a/test/unit/middleware/issueDetails.middleware.test.js
+++ b/test/unit/middleware/issueDetails.middleware.test.js
@@ -40,7 +40,7 @@ describe('issueDetails.middleware.js', () => {
         // middleware supplies the below
         entryNumber: 1,
         entityCount: { entity_count: 1 },
-        issueEntitiesCount: 1,
+        issueEntitiesCount: { count: 1 },
         pageNumber: 1,
         orgInfo,
         dataset,
@@ -140,7 +140,7 @@ describe('issueDetails.middleware.js', () => {
         // middleware supplies the below
         entryNumber: 1,
         entityCount: { entity_count: 3 },
-        issueEntitiesCount: 1,
+        issueEntitiesCount: { count: 1 },
         pageNumber: 1,
         orgInfo,
         dataset,

--- a/test/unit/middleware/middleware.builders.test.js
+++ b/test/unit/middleware/middleware.builders.test.js
@@ -137,4 +137,27 @@ describe('middleware.builders', () => {
       expect(fallbackPolicy).toHaveBeenCalledOnce()
     })
   })
+
+  describe('handleRejections', async () => {
+    const trouble = async () => Promise.reject(new Error('something failed'))
+
+    it('should handle rejections', async () => {
+      const mw = middleware.handleRejections(async (req, res, next) => {
+        await trouble()
+      })
+      const next = vi.fn()
+      await mw({}, {}, next)
+
+      expect(next).toHaveBeenCalledTimes(1)
+      expect(next).toHaveBeenCalledWith(expect.any(Error))
+    })
+
+    it('should invoke the wrapped middleware', async () => {
+      const mw = middleware.handleRejections(async (req, res, next) => next())
+      const next = vi.fn()
+      await mw({}, {}, next)
+
+      expect(next).toHaveBeenCalledTimes(1)
+    })
+  })
 })


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Bug Fix

## Description

Due to the combination of the following: 
- data fetches that don't go through our generic middleware (`fetchOne`/`fetchMany`) don't handle promise rejections
- express 4.x doesn't handle promise rejections in the middleware

We sometimes end up with unhandled errors (e.g. in `fetchEntry()`).

We can't switch to 5.x (at least not easily, the wizard library relies on something that broke between 4.x and 5.x), so we have to handle this explicitly. This PR adds a wrapper middleware to handle such errors for the few cases where `fetchOne()`/`fetchMany()` isn't used. 500 error is returned now.

Also, moves some of the data fetches to use generic middleware and removes some dead code.

## Related Tickets & Documents

No ticket, but related [Sentry](https://planning-data-platform.sentry.io/issues/5995943040/?environment=production&project=4507033205800960&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=24h&stream_index=0) error

## Added/updated tests?

- [x] Yes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new utility for improved error handling in asynchronous middleware.
	- Added pagination support for issue queries with a defined limit.

- **Bug Fixes**
	- Enhanced error handling to prevent unhandled promise rejections in middleware functions.

- **Documentation**
	- Updated comments and JSDoc annotations to reflect new method signatures and functionalities.

- **Tests**
	- Expanded test coverage for new error handling scenarios and updated existing tests to accommodate changes in data structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->