### PR TITLE
Allows LPAs with no boundaries to display data

### DIFF
--- a/test/unit/javascript/map.test.js
+++ b/test/unit/javascript/map.test.js
@@ -64,18 +64,6 @@ describe('map.js', () => {
       expect(result).toEqual([[-5, -5], [15, 15]])
     })
 
-    it('should handle flyTo method correctly', () => {
-      const map = new Map({ containerId: 'map', data: [], interactive: true })
-      const location = [-1.123, 50.789]
-
-      map.moveMapToLocation(location)
-
-      expect(map.map.flyTo).toHaveBeenCalledWith({
-        center: location,
-        zoom: 11
-      })
-    })
-
     it('should set first map layer id on map load', () => {
       const map = new Map({ containerId: 'map', data: [], interactive: true })
 
@@ -97,6 +85,13 @@ describe('map.js', () => {
       const result = calculateBoundingBoxFromGeometries(geometries)
 
       expect(result).toEqual([[-25, -25], [15, 15]])
+    })
+
+    it('should return empty array if geometry is undefined', () => {
+      const geometries = undefined
+      const result = calculateBoundingBoxFromGeometries(geometries)
+
+      expect(result).toEqual([])
     })
   })
 


### PR DESCRIPTION

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases, this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

There was a bug where if the LPA didn't have a boundary JSON, it would fail to display.

If a LPA does not have a boundary in our system, it will now use the GeoJSON urls to set the bounding box.

## Preview Link

https://submit-pr-695.herokuapp.com/organisations/local-authority:BST/article-4-direction-area/overview

## Related Tickets & Documents

<!--
For pull requests that relate to or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example, having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, GitHub will
automatically close the issue.
-->
- Ticket Link
- Related Issue #
- Closes #559

## QA Instructions, Screenshots, Recordings

<!--
Instructions on how to test your changes, a note
on the devices and browsers, this has been tested on, as well as any relevant
images for UI changes.
-->
### Before

![Screenshot 2024-11-26 at 1 58 19 pm](https://github.com/user-attachments/assets/be3a06ce-2868-4e86-baed-e83aef1b0599)

### After

![Screenshot 2024-11-26 at 2 33 29 pm](https://github.com/user-attachments/assets/7f8c72a1-5d61-4a34-8b8a-ed2b37f68e0e)


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _Please replace this line with details on why tests have not been included_
- [ ] I need help with writing tests

## QA sign off
- [ ] Code has been checked and approved
- [ ] Design has been checked and approved
- [ ] Product and business logic has been checked and proved

## [optional] Are there any post-deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced asynchronous handling for loading map data, improving performance and user experience.
	- Improved error handling for bounding box logic, ensuring robustness against empty inputs.

- **Bug Fixes**
	- Updated behaviour for the `calculateBoundingBoxFromGeometries` function to return an empty array when no geometries are provided.

- **Tests**
	- Removed outdated test for the `flyTo` method.
	- Added new test case to ensure correct handling of undefined geometries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->