### PR TITLE
Update content for brownfield land banner

### DIFF
--- a/src/views/components/deadlineNotice.html
+++ b/src/views/components/deadlineNotice.html
@@ -3,9 +3,9 @@
 
 {% macro deadlineNotice(datasetName, notice, organisation) %}
   {% set html %}
-    <p class="govuk-notification-banner__heading">{{ noticeHeading(datasetName, notice) }}</p> 
-    <p class="govuk-body">{{ noticeHint(notice) }}</p>
-    {{ noticeLink(organisation.organisation, datasetName) }}
+    <p class="govuk-notification-banner__heading">{{ noticeHeading(datasetName, notice) }}</p>
+    <p class="govuk-body govuk-notification-banner__body">{{ noticeHint(notice, datasetName) }}</p>
+    <p class="govuk-body govuk-notification-banner__cta">{{ noticeLink(organisation.organisation, datasetName) }}</p>
   {% endset %}
 
   {{ govukNotificationBanner({

--- a/src/views/components/deadlineNoticeContent.html
+++ b/src/views/components/deadlineNoticeContent.html
@@ -1,24 +1,26 @@
 {% macro noticeHeading(datasetName, notice) %}
   {% if notice.type == 'due' %}
-    You are required to update your {{datasetName | datasetSlugToReadableName | lower}} dataset by {{notice.deadline}}
+    You must review your {{datasetName | datasetSlugToReadableName | lower}} register by {{notice.deadline}}
   {% elseif notice.type == 'overdue' %}
     Your {{datasetName | datasetSlugToReadableName | lower}} dataset is overdue
   {% endif %}
 {% endmacro %}
 
-{% macro noticeHint(notice) %}
-  {% if notice.type == 'overdue' %}
+{% macro noticeHint(notice, datasetName) %}
+  {% if notice.type == 'due' %}
+    Update your register as soon as a new {{datasetName | datasetSlugToReadableName | lower}} site is identified or an existing one changes status, to increase trust in the data.
+  {% elseif notice.type == 'overdue' %}
     It was due on {{notice.deadline}}
   {% endif %}
 {% endmacro %}
 
 {% macro noticeLink(organisation, slug) %}
-  <a class="govuk-notification-banner__link" href="/organisations/{{organisation}}/{{slug}}/get-started">Follow the steps and check your data meets the specifications before you publish and submit it</a>.
+  <a class="govuk-notification-banner__link" href="/organisations/{{organisation}}/{{slug}}/get-started">Follow the steps and check your data meets the specifications before you provide it.</a>
 {% endmacro %}
 
-{% macro noticeCardHint(notice) %}
+{% macro noticeCardHint(notice, datasetName) %}
   {% if notice.type == 'due' %}
-    You are required to update this dataset by {{notice.deadline}}
+    You must review your {{datasetName | datasetSlugToReadableName | lower}} register by {{notice.deadline}} and update it as soon as a new site is identified or an existing one changes status.
   {% elseif notice.type == 'overdue' %}
     This dataset is overdue
   {% endif %}

--- a/src/views/organisations/overview.html
+++ b/src/views/organisations/overview.html
@@ -27,7 +27,7 @@
     </h2>
     <div class="govuk-task-list__hint">
       {% if dataset.notice %}
-        <p>{{ noticeCardHint(dataset.notice) }}</p>
+        <p>{{ noticeCardHint(dataset.notice, dataset.dataset) }}</p>
       {% elif dataset.status == 'Not submitted' %}
         <p>Data URL not submitted</p>
       {% elif dataset.status == 'Error' %}

--- a/test/unit/views/organisations/dataset-overview.test.js
+++ b/test/unit/views/organisations/dataset-overview.test.js
@@ -136,7 +136,9 @@ describe('Dataset Overview Page', () => {
 
     expect(documentWithNotice.querySelector('.govuk-notification-banner')).not.toBeNull()
     expect(banner.classList.contains('govuk-notification-banner--warning')).toBeFalsy()
-    expect(banner.textContent).toContain(`You are required to update your ${paramsWithNotice.dataset.dataset} dataset by deadline`)
+    expect(banner.querySelector('.govuk-notification-banner__heading').textContent).toContain(`You must review your ${paramsWithNotice.dataset.dataset} register by deadline`)
+    expect(banner.querySelector('.govuk-notification-banner__body').textContent).toContain(`Update your register as soon as a new ${paramsWithNotice.dataset.dataset} site is identified or an existing one changes status, to increase trust in the data.`)
+    expect(banner.querySelector('.govuk-notification-banner__cta').textContent).toContain('Follow the steps and check your data meets the specifications before you provide it.')
   })
 
   it('Should render "overdue" notice with correct content', () => {

--- a/test/unit/views/organisations/lpaOverviewPage.test.js
+++ b/test/unit/views/organisations/lpaOverviewPage.test.js
@@ -84,7 +84,7 @@ describe(`LPA Overview Page (seed: ${seed})`, () => {
       let expectedHint = 'Data URL submitted'
       if (dataset.notice) {
         if (dataset.notice.type === 'due') {
-          expectedHint = `You are required to update this dataset by ${dataset.notice.deadline}`
+          expectedHint = `You must review your ${datasetSlugToReadableName(dataset.dataset)} register by ${dataset.notice.deadline} and update it as soon as a new site is identified or an existing one changes status.`
         } else if (dataset.notice.type === 'overdue') {
           expectedHint = `Your ${datasetSlugToReadableName(dataset.dataset)} dataset is overdue`
         } else {
@@ -164,7 +164,7 @@ describe(`LPA Overview Page (seed: ${seed})`, () => {
         let expectedHint
 
         if (dataset.notice.type === 'due') {
-          expectedHeader = `You are required to update your ${datasetSlugToReadableName(dataset.dataset).toLowerCase()} dataset by ${dataset.notice.deadline}`
+          expectedHeader = `You must review your ${datasetSlugToReadableName(dataset.dataset).toLowerCase()} register by ${dataset.notice.deadline}`
         } else if (dataset.notice.type === 'overdue') {
           expectedHeader = `Your ${datasetSlugToReadableName(dataset.dataset).toLowerCase()} dataset is overdue`
           expectedHint = `It was due on ${dataset.notice.deadline}`


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases, this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

## Context:

- The in-service notifications to prompt LPAs to review their brownfield land data currently states that LPAs "must update" their brownfield registers, whereas the guidance states that they are required to review these on a yearly basis, and that they should then update the registers if there have been any changes.
- To ensure that the content of the notifications is in line with the guidance, the banner and the dashboard content should be updated as per: https://docs.google.com/document/d/1i2UoeFYlBUuz5vkXdu4d4Oe4Keef98g9SNL24z4NwgU/edit?tab=t.0


### Banner:

> #### You must review your brownfield land register by 31 December 2024
> 
> Update your register as soon as a new brownfield site is identified or an existing one changes status, to increase trust in the data.
> 
> Follow the steps and check your data meets the specifications before you provide it.


### Dashboard content:

> You must review your brownfield land register by 31 December 2024 and update it as soon as a new site is identified or an existing one changes status.

## Related Tickets & Documents

<!--
For pull requests that relate to or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example, having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, GitHub will
automatically close the issue.
-->
- Ticket Link
- Related Issue #
- Closes #708

## QA Instructions, Screenshots, Recordings

<!--
Instructions on how to test your changes, a note
on the devices and browsers, this has been tested on, as well as any relevant
images for UI changes.
-->
### Before

<img width="1092" alt="Screenshot 2024-12-02 at 3 53 58 pm" src="https://github.com/user-attachments/assets/4dc18b53-44b2-4b1b-93be-438a86a4517f">
<img width="1155" alt="Screenshot 2024-12-02 at 3 54 06 pm" src="https://github.com/user-attachments/assets/126357dc-1423-42a5-a502-cb94692a84e0">


### After

<img width="1093" alt="Screenshot 2024-12-02 at 3 53 38 pm" src="https://github.com/user-attachments/assets/7338a548-47fb-4971-8d06-4c3682488ea5">
<img width="1138" alt="Screenshot 2024-12-02 at 3 53 47 pm" src="https://github.com/user-attachments/assets/0b91d2a2-9384-4467-ad29-a3eb86e85826">


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _Please replace this line with details on why tests have not been included_
- [ ] I need help with writing tests

## QA sign off
- [ ] Code has been checked and approved
- [ ] Design has been checked and approved
- [ ] Product and business logic has been checked and proved

## [optional] Are there any post-deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced notification banners for dataset deadlines, providing clearer messages and calls to action.
  - Updated wording in notices to emphasise the importance of reviewing datasets as soon as changes occur.

- **Bug Fixes**
  - Improved rendering of notification banners to ensure accurate display of messages for 'due' and 'overdue' notices.

- **Tests**
  - Expanded test cases to verify the updated content and structure of notification banners, ensuring robustness in messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->