### PR TITLE
fix: uncaught exception in case of missing source

### DIFF
--- a/src/middleware/datasetOverview.middleware.js
+++ b/src/middleware/datasetOverview.middleware.js
@@ -126,12 +126,12 @@ export const setNoticesFromSourceKey = (sourceKey) => (req, res, next) => {
 
     const { deadlineDate, lastYearDeadline, twoYearsAgoDeadline } = getDeadlineHistory(deadlineObj.deadline)
 
-    const startDate = new Date(source.startDate)
+    const startDate = source ? new Date(source.startDate) : undefined
 
-    if (startDate.toString() === 'Invalid Date') {
+    if (!startDate || startDate.toString() === 'Invalid Date') {
       logger.warn('Invalid start date encountered', {
         type: types.DataValidation,
-        startDate: source.startDate
+        startDate: source?.startDate
       })
       return next()
     }

--- a/test/unit/middleware/datasetOverview.middleware.test.js
+++ b/test/unit/middleware/datasetOverview.middleware.test.js
@@ -203,5 +203,13 @@ describe('Dataset Overview Middleware', () => {
 
       expect(reqWithDataset.notice).toBeUndefined()
     })
+
+    it('should handle missing source key gracefully', () => {
+      const reqWithoutSource = {
+        ...req
+      }
+      setNoticesFromSourceKey('foobar')(reqWithoutSource, res, () => {})
+      expect(reqWithoutSource.notice).toBeUndefined()
+    })
   })
 })


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Sometimes the 'source' in request object is not present and we end up accessing a member (`startDate`) in `undefined` value. 

## Added/updated tests?

- [x] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for cases where the source object may be undefined, ensuring robust behaviour of the middleware.

- **Tests**
	- Added a new test case to verify the middleware's behaviour when an invalid source key is provided, enhancing test coverage for edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->