### PR TITLE
Prevent bots from crawling/indexing certain pages

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Disallow: /check/status
+Disallow: /check/results
+Disallow: /organisations/*
+Allow: /organisations/*/overview

--- a/src/middleware/common.middleware.js
+++ b/src/middleware/common.middleware.js
@@ -643,7 +643,7 @@ export const noIndexHeader = (req, res, next) => {
  * @param next
  */
 export const preventIndexing = (req, res, next) => {
-  if (/^\/organisations\/[\w-:]+\/.*$/.test(req.originalUrl)) {
+  if (/^\/organisations\/[\w-:]+\/.*$|^\/check\/status.*$|\/check\/results.*$/.test(req.originalUrl)) {
     return noIndexHeader(req, res, next)
   }
   next()

--- a/src/middleware/common.middleware.js
+++ b/src/middleware/common.middleware.js
@@ -629,3 +629,22 @@ export const prepareIssueDetailsTemplateParams = (req, res, next) => {
 
   next()
 }
+
+export const noIndexHeader = (req, res, next) => {
+  res.set('X-Robots-Tag', 'noindex')
+  next()
+}
+
+/**
+ * Middleware. Prevents indexing of certain pages
+ *
+ * @param req
+ * @param res
+ * @param next
+ */
+export const preventIndexing = (req, res, next) => {
+  if (/^\/organisations\/[\w-:]+\/.*$/.test(req.originalUrl)) {
+    return noIndexHeader(req, res, next)
+  }
+  next()
+}

--- a/src/serverSetup/middlewares.js
+++ b/src/serverSetup/middlewares.js
@@ -5,6 +5,7 @@ import logger from '../utils/logger.js'
 import { types } from '../utils/logging.js'
 import hash from '../utils/hasher.js'
 import config from '../../config/index.js'
+import { preventIndexing } from '../middleware/common.middleware.js'
 
 export function setupMiddlewares (app) {
   app.use((req, res, next) => {
@@ -28,6 +29,7 @@ export function setupMiddlewares (app) {
 
   app.use(cookieParser())
   app.use(bodyParser.urlencoded({ extended: true }))
+  app.use(preventIndexing)
 
   app.use((req, res, next) => {
     const serviceDown = config.maintenance.serviceUnavailable || false

--- a/src/serverSetup/middlewares.js
+++ b/src/serverSetup/middlewares.js
@@ -24,6 +24,7 @@ export function setupMiddlewares (app) {
   app.use('/assets', express.static('./node_modules/govuk-frontend/dist/govuk/assets'))
   app.use('/assets', express.static('./node_modules/@x-govuk/govuk-prototype-components/x-govuk'))
   app.use('/public', express.static('./public'))
+  app.use('/robots.txt', express.static('./robots.txt'))
 
   app.use(cookieParser())
   app.use(bodyParser.urlencoded({ extended: true }))

--- a/test/unit/middleware/common.middleware.test.js
+++ b/test/unit/middleware/common.middleware.test.js
@@ -1550,13 +1550,13 @@ describe('preventIndexing middleware', () => {
     preventIndexing(req, res, vi.fn())
     expect(res.set).toBeCalledWith('X-Robots-Tag', 'noindex')
   })
-  it('should set headers on the check tool status page', () =>{
+  it('should set headers on the check tool status page', () => {
     const req = { originalUrl: '/check/status/PHvgmEPg4EQWGvr646vuMz' }
     const res = { set: vi.fn() }
     preventIndexing(req, res, vi.fn())
     expect(res.set).toBeCalledWith('X-Robots-Tag', 'noindex')
   })
-  it('should set headers on the check tool results page', () =>{
+  it('should set headers on the check tool results page', () => {
     const req = { originalUrl: '/check/results/PHvgmEPg4EQWGvr646vuMz/0' }
     const res = { set: vi.fn() }
     preventIndexing(req, res, vi.fn())

--- a/test/unit/middleware/common.middleware.test.js
+++ b/test/unit/middleware/common.middleware.test.js
@@ -1,5 +1,24 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { filterOutEntitiesWithoutIssues, createPaginationTemplateParams, addDatabaseFieldToSpecification, replaceUnderscoreInSpecification, pullOutDatasetSpecification, extractJsonFieldFromEntities, replaceUnderscoreInEntities, setDefaultParams, getUniqueDatasetFieldsFromSpecification, show404IfPageNumberNotInRange, FilterOutIssuesToMostRecent, removeIssuesThatHaveBeenFixed, addFieldMappingsToIssue, getSetDataRange, getErrorSummaryItems, getSetBaseSubPath, prepareIssueDetailsTemplateParams } from '../../../src/middleware/common.middleware'
+import {
+  filterOutEntitiesWithoutIssues,
+  createPaginationTemplateParams,
+  addDatabaseFieldToSpecification,
+  replaceUnderscoreInSpecification,
+  pullOutDatasetSpecification,
+  extractJsonFieldFromEntities,
+  replaceUnderscoreInEntities,
+  setDefaultParams,
+  getUniqueDatasetFieldsFromSpecification,
+  show404IfPageNumberNotInRange,
+  FilterOutIssuesToMostRecent,
+  removeIssuesThatHaveBeenFixed,
+  addFieldMappingsToIssue,
+  getSetDataRange,
+  getErrorSummaryItems,
+  getSetBaseSubPath,
+  prepareIssueDetailsTemplateParams,
+  preventIndexing
+} from '../../../src/middleware/common.middleware'
 import logger from '../../../src/utils/logger'
 import datasette from '../../../src/services/datasette.js'
 import performanceDbApi from '../../../src/services/performanceDbApi.js'
@@ -1497,5 +1516,38 @@ describe('filterOutEntitiesWithoutIssues middleware', () => {
       { entity: 'entity2' },
       { entity: 'entity3' }
     ])
+  })
+})
+
+describe('preventIndexing middleware', () => {
+  it('should not set headers on the organisation search page', () => {
+    const req = { originalUrl: '/some-other-page' }
+    const res = { set: vi.fn() }
+    preventIndexing(req, res, vi.fn())
+    expect(res.set).not.toBeCalled()
+  })
+  it('should not set headers on the organisation search page', () => {
+    const req = { originalUrl: '/organisations' }
+    const res = { set: vi.fn() }
+    preventIndexing(req, res, vi.fn())
+    expect(res.set).not.toBeCalled()
+  })
+  it('should not set headers on the LPA page', () => {
+    const req = { originalUrl: '/organisations/foo-bar:ABC' }
+    const res = { set: vi.fn() }
+    preventIndexing(req, res, vi.fn())
+    expect(res.set).not.toBeCalled()
+  })
+  it('should set headers on the dataset page', () => {
+    const req = { originalUrl: '/organisations/foo-bar:ABC/some-dataset/overview' }
+    const res = { set: vi.fn() }
+    preventIndexing(req, res, vi.fn())
+    expect(res.set).toBeCalledWith('X-Robots-Tag', 'noindex')
+  })
+  it('should set headers on the dataset page', () => {
+    const req = { originalUrl: '/organisations/foo-bar:ABC/some-dataset' }
+    const res = { set: vi.fn() }
+    preventIndexing(req, res, vi.fn())
+    expect(res.set).toBeCalledWith('X-Robots-Tag', 'noindex')
   })
 })

--- a/test/unit/middleware/common.middleware.test.js
+++ b/test/unit/middleware/common.middleware.test.js
@@ -1550,4 +1550,16 @@ describe('preventIndexing middleware', () => {
     preventIndexing(req, res, vi.fn())
     expect(res.set).toBeCalledWith('X-Robots-Tag', 'noindex')
   })
+  it('should set headers on the check tool status page', () =>{
+    const req = { originalUrl: '/check/status/PHvgmEPg4EQWGvr646vuMz' }
+    const res = { set: vi.fn() }
+    preventIndexing(req, res, vi.fn())
+    expect(res.set).toBeCalledWith('X-Robots-Tag', 'noindex')
+  })
+  it('should set headers on the check tool results page', () =>{
+    const req = { originalUrl: '/check/results/PHvgmEPg4EQWGvr646vuMz/0' }
+    const res = { set: vi.fn() }
+    preventIndexing(req, res, vi.fn())
+    expect(res.set).toBeCalledWith('X-Robots-Tag', 'noindex')
+  })
 })


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Added a `robots.txt` that disallows indexing most of the dataset pages (as per @stevenjmesser [comment](https://github.com/digital-land/submit/issues/318#issuecomment-2367612563), but allows bots on LPA's pages.

Additionally, added a middleware matching the above rules which sets `X-Robots-Tag` header to `noindex` value ([docs](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag)).

## Related Tickets & Documents

- Closes #318

## QA Instructions, Screenshots, Recordings

No UI changes in this one. 

```
# includes the X-Robots-Tag header
curl -I https://submit-pr-754.herokuapp.com/organisations/local-authority:ADU/brownfield-land/overview

# does not include the X-Robots-Tag header
curl -I https://submit-pr-754.herokuapp.com/organisations/local-authority:ADU
```


## Added/updated tests?

- [x] Yes

## QA sign off
- [ ] Code has been checked and approved
- [ ] Design has been checked and approved
- [ ] Product and business logic has been checked and proved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated `robots.txt` to control web crawler access to specific paths.
	- Introduced middleware functions to manage HTTP headers for preventing page indexing.
- **Bug Fixes**
	- Enhanced middleware execution order for improved request processing.
- **Tests**
	- Added test cases for the new middleware to ensure correct behaviour regarding page indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->