### PR TITLE
gathering datasette query information

### DIFF
--- a/config/local.yaml
+++ b/config/local.yaml
@@ -13,7 +13,7 @@ redis: {
     port: 6379
 }
 port: 5000
-url: 'http://localhost:5000/'features:
+url: 'http://localhost:5000/'
 features:
   request-info:
     environments: ['local']

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -17,4 +17,4 @@ url: 'http://localhost:5000/'
 features:
   request-info:
     environments: ['local']
-    enabled: true
+    enabled: false

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -14,6 +14,7 @@ redis: {
 }
 port: 5000
 url: 'http://localhost:5000/'features:
+features:
   request-info:
     environments: ['local']
-    enabled: false
+    enabled: true

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -16,8 +16,6 @@ port: 5000
 url: 'http://localhost:5000/'
 features:
   request-info:
-    environments: ['local']
     enabled: false
   query-metrics:
-    environments: ['local']
     enabled: true

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -18,3 +18,6 @@ features:
   request-info:
     environments: ['local']
     enabled: false
+  query-metrics:
+    environments: ['local']
+    enabled: true

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -13,4 +13,7 @@ redis: {
     port: 6379
 }
 port: 5000
-url: 'http://localhost:5000/'
+url: 'http://localhost:5000/'features:
+  request-info:
+    environments: ['local']
+    enabled: false

--- a/config/util.js
+++ b/config/util.js
@@ -99,7 +99,12 @@ export const ConfigSchema = v.object({
     issues: v.object({
       email: v.pipe(v.string(), v.email())
     })
-  })
+  }),
+  features: v.optional(v.record(
+    v.string(), v.object({
+      enabled: v.boolean(),
+      environments: v.optional(v.array(v.string()))
+    })))
 })
 
 const readConfig = (config) => {

--- a/config/util.js
+++ b/config/util.js
@@ -102,8 +102,7 @@ export const ConfigSchema = v.object({
   }),
   features: v.optional(v.record(
     v.string(), v.object({
-      enabled: v.boolean(),
-      environments: v.optional(v.array(v.string()))
+      enabled: v.boolean()
     })))
 })
 

--- a/src/controllers/lpaDetailsController.js
+++ b/src/controllers/lpaDetailsController.js
@@ -3,7 +3,7 @@ import { fetchLocalAuthorities } from '../utils/datasetteQueries/fetchLocalAutho
 
 class LpaDetailsController extends PageController {
   async locals (req, res, next) {
-    const localAuthoritiesNames = await fetchLocalAuthorities()
+    const localAuthoritiesNames = await fetchLocalAuthorities({ req })
 
     const listItems = localAuthoritiesNames.map(name => ({
       text: name,

--- a/src/middleware/common.middleware.js
+++ b/src/middleware/common.middleware.js
@@ -208,7 +208,7 @@ export const addEntityCountsToResources = async (req, res, next) => {
 
   const promises = resources.map(resource => {
     const query = `SELECT entry_count FROM dataset_resource WHERE resource = "${resource.resource}"`
-    return datasette.runQuery(query, resource.dataset)
+    return datasette.runQuery(query, resource.dataset, { req })
   })
 
   try {
@@ -447,8 +447,8 @@ export const removeIssuesThatHaveBeenFixed = async (req, res, next) => {
         AND fr.resource IN ('${newerResources.map(resource => resource.resource).join("','")}')
         ORDER BY fr.start_date desc
         LIMIT 1`,
-      issue.dataset
-      )
+      issue.dataset,
+      { req })
     })
 
   Promise.allSettled(promises).then((results) => {

--- a/src/middleware/middleware.builders.js
+++ b/src/middleware/middleware.builders.js
@@ -88,7 +88,7 @@ async function fetchOneFn (req, res, next) {
   logger.debug({ type: types.DataFetch, message: 'fetchOne', resultKey: this.result })
   try {
     const query = this.query({ req, params: req.params })
-    const result = await datasette.runQuery(query, datasetOverride(this.dataset, req), { req })
+    const result = await datasette.runQuery(query, datasetOverride(this.dataset, req), { req, resultKey: this.result })
     const fallbackPolicy = this.fallbackPolicy ?? FetchOneFallbackPolicy['not-found-error']
     if (result.formattedData.length === 0) {
       // we can make the 404 more informative by informing the use what exactly was "not found"
@@ -116,7 +116,7 @@ async function fetchOneFn (req, res, next) {
 export async function fetchManyFn (req, res, next) {
   try {
     const query = this.query({ req, params: req.params })
-    const result = await datasette.runQuery(query, datasetOverride(this.dataset, req), { req })
+    const result = await datasette.runQuery(query, datasetOverride(this.dataset, req), { req, resultKey: this.result })
     req[this.result] = result.formattedData
     logger.debug({ type: types.DataFetch, message: 'fetchMany', resultKey: this.result, resultCount: result.formattedData.length })
     next()
@@ -151,7 +151,7 @@ export async function fetchOneFromAllDatasetsFn (req, res, next) {
   try {
     const query = this.query({ req, params: req.params })
     const promises = availableDatasets.map((dataset) => {
-      return datasette.runQuery(query, dataset, { req }).catch(error => {
+      return datasette.runQuery(query, dataset, { req, resultKey: this.result }).catch(error => {
         logger.error('Query failed for dataset', { dataset, errorMessage: error.message, errorStack: error.stack, type: types.DataFetch })
         throw error
       })
@@ -191,7 +191,7 @@ export async function fetchManyFromAllDatasetsFn (req, res, next) {
   try {
     const query = this.query({ req, params: req.params })
     const promises = availableDatasets.map((dataset) => {
-      return datasette.runQuery(query, dataset, { req }).catch(error => {
+      return datasette.runQuery(query, dataset, { req, resultKey: this.result }).catch(error => {
         logger.error('Query failed for dataset', { dataset, errorMessage: error.message, errorStack: error.stack, type: types.DataFetch })
         throw error
       })

--- a/src/middleware/organisations.middleware.js
+++ b/src/middleware/organisations.middleware.js
@@ -3,7 +3,7 @@ import { fetchMany, renderTemplate } from './middleware.builders.js'
 
 const fetchOrganisations = fetchMany({
   query: ({ req, params }) => {
-    return `
+    return /* sql */ `
       SELECT
         name,
         organisation

--- a/src/serverSetup/errorHandlers.js
+++ b/src/serverSetup/errorHandlers.js
@@ -2,6 +2,8 @@ import logger from '../utils/logger.js'
 import { types } from '../utils/logging.js'
 import { MiddlewareError, errorTemplateContext } from '../utils/errors.js'
 
+const requestIdKey = Symbol.for('reqId')
+
 export function setupErrorHandlers (app) {
   const errContext = errorTemplateContext()
   app.use((err, req, res, next) => {
@@ -12,7 +14,8 @@ export function setupErrorHandlers (app) {
       message: 'error occurred',
       error: JSON.stringify(err),
       errorMessage: err.message,
-      errorStack: err.stack
+      errorStack: err.stack,
+      reqId: req[requestIdKey]
     })
 
     if (res.headersSent) {

--- a/src/serverSetup/middlewares.js
+++ b/src/serverSetup/middlewares.js
@@ -7,13 +7,89 @@ import hash from '../utils/hasher.js'
 import config from '../../config/index.js'
 import { preventIndexing } from '../middleware/common.middleware.js'
 import { MiddlewareError, errorTemplateContext } from '../utils/errors.js'
+import { isFeatureEnabled } from '../utils/features.js'
+import { v4 as uuidv4 } from 'uuid'
+
+const requestId = Symbol.for('reqId')
+const requestInfo = Symbol.for('requestInfo')
+
+/**
+ * @type {Map<string,{{ url: string, id: string, query: string}[]}>}
+ */
+const store = new Map()
+
+const makeRequestInfoConsumer = (storage) => {
+  return {
+    /**
+     * @param {{url: string, id: string}} info request info
+     * @returns {number} index in the array of queries for the request
+     */
+    log (info) {
+      let fetches = storage.get(info.id)
+      if (fetches) {
+        fetches.push(info)
+      } else {
+        fetches = [info]
+        storage.set(info.id, fetches)
+      }
+      return fetches.length - 1
+    },
+    /**
+     *
+     * @param {import('express'.Request)} req
+     * @param {string} query
+     * @param {number} duration milliseconds
+     * @returns {number} index in the array of queries for the request
+     */
+    logRequest (req, query, duration) {
+      const id = req[requestId]
+      const info = {
+        id,
+        url: req.originalUrl,
+        query,
+        duration
+      }
+      return this.log(info)
+    }
+  }
+}
+
+const makeNoopRequestInfoConsumer = () => {
+  return {
+    log (info) {},
+    logRequest (req, query, duration) {}
+  }
+}
+
+const requestInfoStoreEnabled = isFeatureEnabled(config, 'request-info')
+
+function addRequestId (req, res, next) {
+  req[requestId] = uuidv4()
+  req[requestInfo] = requestInfoStoreEnabled ? makeRequestInfoConsumer(store) : makeNoopRequestInfoConsumer()
+  next()
+}
+
+/**
+ * Middleware. Allows to fethch request info. This is a develpment aid and should not
+ * be enabled in production as the store grows unbounded. The endpoint returns
+ * JSON object of UUID -> { id, url, query }[].
+ */
+const requestInfoRoute = async (req, res, next) => {
+  const jsonBody = {}
+  for (const [k, v] of store.entries()) {
+    jsonBody[k] = v
+  }
+  res.json(jsonBody)
+}
 
 export function setupMiddlewares (app) {
+  app.use(addRequestId)
   app.use((req, res, next) => {
     const obj = {
       type: types.Request,
       method: req.method,
       endpoint: req.originalUrl,
+      reqId: req[requestId],
       message: '◦' // we need to put something here or watson will use an obj as the message
     }
     if (req.sessionID) {
@@ -41,4 +117,8 @@ export function setupMiddlewares (app) {
       next()
     }
   })
+
+  if (requestInfoStoreEnabled) {
+    app.use('/request-info', requestInfoRoute)
+  }
 }

--- a/src/services/datasette.js
+++ b/src/services/datasette.js
@@ -23,7 +23,7 @@ export default {
  *
  * @param {string} query - The SQL query to execute.
  * @param {string} database - The name of the database to query. Defaults to 'digital-land'.
- * @param {{ req: import('express').Request} | undefined} opts - options
+ * @param {{ req: import('express').Request} & { resultKey: string } | undefined} opts - options
  * @returns {Promise<{data: object, formattedData: object[]}>} - A promise that resolves to an object with the following properties:
  *   - `data`: The raw data returned by Datasette.
  *   - `formattedData`: The formatted data, with columns and rows parsed into a usable format.
@@ -48,7 +48,7 @@ export default {
         const duration = performance.now() - start
         const reqId = req[requestId]
         if ('metric' in req.query) {
-          logger.info('runQuery()', { type: types.Metric, reqId, duration, endpoint: req.originalUrl, database })
+          logger.info('runQuery()', { type: types.Metric, reqId, duration, endpoint: req.originalUrl, database, resultKey: opts.resultKey })
         }
         saveFetchInfo(req, query, duration)
       }

--- a/src/services/datasette.js
+++ b/src/services/datasette.js
@@ -1,6 +1,8 @@
 import axios from 'axios'
 import logger from '../utils/logger.js'
+import config from '../../config/index.js'
 import { types } from '../utils/logging.js'
+import { isFeatureEnabled } from '../utils/features.js'
 
 const datasetteUrl = 'https://datasette.planning.data.gov.uk'
 
@@ -16,6 +18,8 @@ const requestId = Symbol.for('reqId')
 function saveFetchInfo (req, query, duration) {
   return req[requestInfo].logRequest(req, query, duration)
 }
+
+const queryMetricsEnabled = isFeatureEnabled(config, 'query-metrics')
 
 export default {
   /**
@@ -47,7 +51,7 @@ export default {
       if (req) {
         const duration = performance.now() - start
         const reqId = req[requestId]
-        if ('metric' in req.query) {
+        if (queryMetricsEnabled && 'metric' in req.query) {
           logger.info('runQuery()', { type: types.Metric, reqId, duration, endpoint: req.originalUrl, database, resultKey: opts.resultKey })
         }
         saveFetchInfo(req, query, duration)

--- a/src/services/performanceDbApi.js
+++ b/src/services/performanceDbApi.js
@@ -1,7 +1,6 @@
 /**
  * Performance DB API service
  */
-import datasette from './datasette.js'
 import logger from '../utils/logger.js'
 import { types } from '../utils/logging.js'
 
@@ -282,36 +281,6 @@ export default {
       and "organisation" = '${lpa}'
       and "dataset" in (${params.datasetsFilter.map(dataset => `'${dataset}'`).join(',')})
     order by dataset asc`
-  },
-
-  /**
-    *
-    * @param {{resource: string, dataset: string}[]} resources
-    * @param {{ req?: import('express').Request}}
-    * @returns {Promise<{ resource: string, dataset: string, entityCount?: number}[]>}
-    */
-  async getEntityCounts (resources, opts = {}) {
-    const requests = resources.map(({ resource, dataset }) => {
-      const q = datasette.runQuery(this.entityCountQuery(resource), dataset, opts)
-      return q
-        .then(result => {
-          if (result.formattedData.length === 0) {
-            logger.info({ message: 'getEntityCounts(): No results for resource.', resource, dataset, type: types.App })
-            return { resource, dataset }
-          }
-          return { resource, dataset, entityCount: result.formattedData[0].entity_count }
-        })
-        .catch((error) => {
-          logger.warn('getEntityCounts(): could not obtain entity counts. Proceeding without them.',
-            { type: types.App, errorMessage: error.message, errorStack: error.stack })
-          return { resource, dataset }
-        })
-    })
-
-    const results = await Promise.allSettled(requests)
-    return results
-      .filter(p => p.status === 'fulfilled')
-      .map(p => p.value)
   },
 
   getEntitiesWithIssuesCountQuery: (req) => {

--- a/src/utils/datasetteQueries/fetchLocalAuthorities.js
+++ b/src/utils/datasetteQueries/fetchLocalAuthorities.js
@@ -26,7 +26,7 @@ export const fetchLocalAuthorities = async (opts = {}) => {
       provision.organisation`
 
   try {
-    const response = await datasette.runQuery(sql, 'digital-land', opts)
+    const response = await datasette.runQuery(sql, 'digital-land', { ...opts, resultKey: 'fetchLocalAuthorities' })
     const names = response.formattedData.map(row => {
       if (row.name == null) {
         logger.debug('Null value found in response:', row)

--- a/src/utils/datasetteQueries/fetchLocalAuthorities.js
+++ b/src/utils/datasetteQueries/fetchLocalAuthorities.js
@@ -8,10 +8,11 @@ import logger from '../logger.js'
  * It performs an HTTP GET request to retrieve the data, then processes the response to return
  * only the names of the local authorities.
  *
+ * @param {{ req?: import('express').Request}} opts options (optional)
  * @returns {Promise<string[]>} A promise that resolves to an array of local authority names.
  * @throws {Error} Throws an error if the HTTP request fails or data processing encounters an issue.
  */
-export const fetchLocalAuthorities = async () => {
+export const fetchLocalAuthorities = async (opts = {}) => {
   const sql = `select
       distinct provision.organisation,
       organisation.name,
@@ -25,7 +26,7 @@ export const fetchLocalAuthorities = async () => {
       provision.organisation`
 
   try {
-    const response = await datasette.runQuery(sql)
+    const response = await datasette.runQuery(sql, 'digital-land', opts)
     const names = response.formattedData.map(row => {
       if (row.name == null) {
         logger.debug('Null value found in response:', row)

--- a/src/utils/datasetteQueries/getDatasetSlugNameMapping.js
+++ b/src/utils/datasetteQueries/getDatasetSlugNameMapping.js
@@ -1,7 +1,11 @@
 import datasette from '../../services/datasette.js'
 
-export const getDatasetSlugNameMapping = async () => {
-  const datasetSlugNameTable = await datasette.runQuery('select dataset, name from dataset')
+/**
+ * @param {{ req?: import('express').Request}} opts options (optional)
+ * @returns {Promise<Map<string, string>}
+ */
+export const getDatasetSlugNameMapping = async (opts = {}) => {
+  const datasetSlugNameTable = await datasette.runQuery('select dataset, name from dataset', 'digital-land', opts)
 
   const datasetMapping = new Map()
   datasetSlugNameTable.rows.forEach(([slug, name]) => {

--- a/src/utils/datasetteQueries/getDatasetSlugNameMapping.js
+++ b/src/utils/datasetteQueries/getDatasetSlugNameMapping.js
@@ -5,7 +5,7 @@ import datasette from '../../services/datasette.js'
  * @returns {Promise<Map<string, string>}
  */
 export const getDatasetSlugNameMapping = async (opts = {}) => {
-  const datasetSlugNameTable = await datasette.runQuery('select dataset, name from dataset', 'digital-land', opts)
+  const datasetSlugNameTable = await datasette.runQuery('select dataset, name from dataset', 'digital-land', { ...opts, resultKey: 'getDatasetSlugNameMapping' })
 
   const datasetMapping = new Map()
   datasetSlugNameTable.rows.forEach(([slug, name]) => {

--- a/src/utils/features.js
+++ b/src/utils/features.js
@@ -11,8 +11,9 @@ import { types } from './logging.js'
  */
 export const isFeatureEnabled = (config, feature) => {
   const env = config.environment
-  const featureConfig = config?.features[feature]
-  if (featureConfig) {
+  const features = config?.features
+  if (features && feature in features) {
+    const featureConfig = features[feature]
     const enabled = (featureConfig.enabled && (featureConfig.environments ?? []).indexOf(env) >= 0)
     logger.info('feature check', { type: types.AppLifecycle, feature: featureConfig, enabled })
     return enabled

--- a/src/utils/features.js
+++ b/src/utils/features.js
@@ -10,12 +10,11 @@ import { types } from './logging.js'
  * @returns {boolean}
  */
 export const isFeatureEnabled = (config, feature) => {
-  const env = config.environment
   const features = config?.features
   if (features && feature in features) {
     const featureConfig = features[feature]
-    const enabled = (featureConfig.enabled && (featureConfig.environments ?? []).indexOf(env) >= 0)
-    logger.info('feature check', { type: types.AppLifecycle, feature: featureConfig, enabled })
+    const enabled = (featureConfig.enabled)
+    logger.info('feature check', { type: types.Feature, feature, config: featureConfig, enabled })
     return enabled
   }
   return false

--- a/src/utils/features.js
+++ b/src/utils/features.js
@@ -13,8 +13,8 @@ export const isFeatureEnabled = (config, feature) => {
   const features = config?.features
   if (features && feature in features) {
     const featureConfig = features[feature]
-    const enabled = (featureConfig.enabled)
-    logger.info('feature check', { type: types.Feature, feature, config: featureConfig, enabled })
+    const enabled = featureConfig.enabled
+    logger.info('feature check', { type: types.Feature, feature, config: featureConfig })
     return enabled
   }
   return false

--- a/src/utils/features.js
+++ b/src/utils/features.js
@@ -1,0 +1,21 @@
+import logger from './logger.js'
+import { types } from './logging.js'
+
+/** @typedef {import('../../config/util.js').ConfigSchema} ConfigSchema */
+
+/**
+ *
+ * @param {any} config config
+ * @param {string} feature feature
+ * @returns {boolean}
+ */
+export const isFeatureEnabled = (config, feature) => {
+  const env = config.environment
+  const featureConfig = config?.features[feature]
+  if (featureConfig) {
+    const enabled = (featureConfig.enabled && (featureConfig.environments ?? []).indexOf(env) >= 0)
+    logger.info('feature check', { type: types.AppLifecycle, feature: featureConfig, enabled })
+    return enabled
+  }
+  return false
+}

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -15,7 +15,8 @@ const types = {
   DataValidation: 'DataValidation',
   DataFetch: 'DataFetch',
   External: 'External',
-  Metric: 'Metric'
+  Metric: 'Metric',
+  Feature: 'Feature'
 }
 
 const logPageView = (route, sessionID) => {

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -14,7 +14,8 @@ const types = {
   App: 'App',
   DataValidation: 'DataValidation',
   DataFetch: 'DataFetch',
-  External: 'External'
+  External: 'External',
+  Metric: 'Metric'
 }
 
 const logPageView = (route, sessionID) => {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases, this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Adds a feature (that has to be enabled via config) to gather information about datasette queries fired by the app.

If enabled, the information will be present under '/request-info' as JSON.

To see how it works. enable the feature, start the app and go to a few pages, then see the output of '/request-info'

To make the above possible the the following changes were needed:
- add unique ID to every request
- update datasette.runQuery() to accept a third (optional) options param which can hold the request object. This allows to link the request and associated datasette queries
- update all the places where runQuery() is called
- also, the execution of remote datasette queries is timed and available in the JSON data returned from '/request-info'
- the metrics are not logged by default (it can be quite noisy), but adding a 'metric' query param to a URL will log them
- a simple `isFeatureEnabled(...)` functionality, probably a temporary solution

An extra piece of code that can do something useful with the gathered information is in this [gist](https://gist.github.com/rosado/be83507f1479e431c1979a034d3fa58d). Not sure where it should live atm, so it's not included in the PR.


## Related Tickets & Documents

#750 

## Added/updated tests?

TODO

- [ ] Yes
- [ ] No, and this is why: _Please replace this line with details on why tests have not been included_
- [ ] I need help with writing tests

## QA sign off
- [ ] Code has been checked and approved
- [ ] Design has been checked and approved
- [ ] Product and business logic has been checked and proved

