### PR TITLE
remove banner middleware steps

### DIFF
--- a/src/middleware/datasetOverview.middleware.js
+++ b/src/middleware/datasetOverview.middleware.js
@@ -213,7 +213,7 @@ export default [
   fetchEntryIssueCounts,
   fetchSpecification,
   pullOutDatasetSpecification,
-  // setNoticesFromSourceKey('resources'),
+  // setNoticesFromSourceKey('resources'), // commented out as the logic is currently incorrect (https://github.com/digital-land/submit/issues/824)
   fetchEntityCount,
   prepareDatasetOverviewTemplateParams,
   getDatasetOverview,

--- a/src/middleware/datasetOverview.middleware.js
+++ b/src/middleware/datasetOverview.middleware.js
@@ -213,7 +213,7 @@ export default [
   fetchEntryIssueCounts,
   fetchSpecification,
   pullOutDatasetSpecification,
-  setNoticesFromSourceKey('resources'),
+  // setNoticesFromSourceKey('resources'),
   fetchEntityCount,
   prepareDatasetOverviewTemplateParams,
   getDatasetOverview,

--- a/src/middleware/overview.middleware.js
+++ b/src/middleware/overview.middleware.js
@@ -329,8 +329,8 @@ export default [
 
   prepareDatasetObjects,
 
-  // datasetSubmissionDeadlineCheck,
-  // addNoticesToDatasets,
+  // datasetSubmissionDeadlineCheck,  // commented out as the logic is currently incorrect (https://github.com/digital-land/submit/issues/824)
+  // addNoticesToDatasets,            // commented out as the logic is currently incorrect (https://github.com/digital-land/submit/issues/824)
   fetchProvisions,
   prepareOverviewTemplateParams,
   getOverview,

--- a/src/middleware/overview.middleware.js
+++ b/src/middleware/overview.middleware.js
@@ -329,8 +329,8 @@ export default [
 
   prepareDatasetObjects,
 
-  datasetSubmissionDeadlineCheck,
-  addNoticesToDatasets,
+  // datasetSubmissionDeadlineCheck,
+  // addNoticesToDatasets,
   fetchProvisions,
   prepareOverviewTemplateParams,
   getOverview,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- Rollback

## Description
Removes the notice banners for now, as the logic is incorrect. see https://github.com/digital-land/submit/issues/824

## QA Instructions, Screenshots, Recordings
looking at https://submit.planning.data.gov.uk/organisations/local-authority:NWM/brownfield-land/overview
in the [preview link](https://submit-pr-827.herokuapp.com/organisations/local-authority:NWM), the banner no longer shows

- No

## QA sign off
- [ ] Code has been checked and approved
- [ ] Design has been checked and approved
- [ ] Product and business logic has been checked and proved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Middleware Changes**
	- Disabled resource notice generation.
	- Removed middleware related to dataset submission deadlines and notices.

These changes modify the middleware processing, potentially affecting how dataset-related notifications and deadline checks are handled in the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->