### PR TITLE
830 refactor results page controller

### DIFF
--- a/src/controllers/pageController.js
+++ b/src/controllers/pageController.js
@@ -25,6 +25,13 @@ function wizardBackLink (currentUrl, deepLinkInfo) {
   return undefined
 }
 
+/**
+ * This class extends the Controller class from the hmpo-form-wizard library.
+ * For more information, please refer to the documentation:
+ * https://github.com/HMPO/hmpo-form-wizard
+ * Specifically, the controller lifecycle is outlined in this PDF:
+ * https://github.com/UKHomeOffice/passports-form-wizard/wiki/HMPO%20Forms%20Flow.pdf
+ */
 class PageController extends Controller {
   checkToolDeepLinkSessionKey = 'check-tool-deep-link'
 

--- a/src/controllers/resultsController.js
+++ b/src/controllers/resultsController.js
@@ -63,17 +63,22 @@ export async function setupTemplate (req, res, next) {
     }
     req.locals.requestParams = req.locals.requestData.getParams()
     next()
-  } catch (error) {
-    next(error, req, res, next)
+  } catch (e) {
+    next(e, req, res, next)
   }
 }
 
 export async function fetchResponseDetails (req, res, next) {
-  if (req.locals.template !== failedFileRequestTemplate && req.locals.template !== failedUrlRequestTemplate) {
-    const responseDetails = req.locals.template === errorsTemplate
-      ? await req.locals.requestData.fetchResponseDetails(req.params.pageNumber, 50, 'error')
-      : await req.locals.requestData.fetchResponseDetails(req.params.pageNumber)
-    req.locals.responseDetails = responseDetails
+  try {
+    if (req.locals.template !== failedFileRequestTemplate && req.locals.template !== failedUrlRequestTemplate) {
+      const responseDetails = req.locals.template === errorsTemplate
+        ? await req.locals.requestData.fetchResponseDetails(req.params.pageNumber, 50, 'error')
+        : await req.locals.requestData.fetchResponseDetails(req.params.pageNumber)
+      req.locals.responseDetails = responseDetails
+    }
+  } catch (e) {
+    next(e, req, res, next)
+    return
   }
   next()
 }

--- a/src/controllers/resultsController.js
+++ b/src/controllers/resultsController.js
@@ -36,7 +36,7 @@ class ResultsController extends PageController {
   }
 }
 
-async function getRequestDataMiddleware (req, res, next) {
+export async function getRequestDataMiddleware (req, res, next) {
   try {
     req.locals = {
       requestData: await getRequestData(req.params.id)
@@ -51,7 +51,7 @@ async function getRequestDataMiddleware (req, res, next) {
   }
 }
 
-async function setupTemplate (req, res, next) {
+export async function setupTemplate (req, res, next) {
   if (req.locals.requestData.isFailed()) {
     if (req.locals.requestData.getType() === 'check_file') {
       req.locals.template = failedFileRequestTemplate
@@ -67,7 +67,7 @@ async function setupTemplate (req, res, next) {
   next()
 }
 
-async function fetchResponseDetails (req, res, next) {
+export async function fetchResponseDetails (req, res, next) {
   if (req.locals.template !== failedFileRequestTemplate && req.locals.template !== failedUrlRequestTemplate) {
     const responseDetails = req.locals.template === errorsTemplate
       ? await req.locals.requestData.fetchResponseDetails(req.params.pageNumber, 50, 'error')
@@ -77,7 +77,7 @@ async function fetchResponseDetails (req, res, next) {
   next()
 }
 
-async function setupTableParams (req, res, next) {
+export async function setupTableParams (req, res, next) {
   if (req.locals.template !== failedFileRequestTemplate && req.locals.template !== failedUrlRequestTemplate) {
     const responseDetails = req.locals.responseDetails
     let rows = responseDetails.getRowsWithVerboseColumns(req.locals.requestData.hasErrors())
@@ -119,7 +119,7 @@ async function setupTableParams (req, res, next) {
   next()
 }
 
-async function setupErrorSummary (req, res, next) {
+export async function setupErrorSummary (req, res, next) {
   if (req.locals.template !== failedFileRequestTemplate && req.locals.template !== failedUrlRequestTemplate) {
     req.locals.errorSummary = req.locals.requestData.getErrorSummary().map(message => {
       return {
@@ -131,7 +131,7 @@ async function setupErrorSummary (req, res, next) {
   next()
 }
 
-async function setupError (req, res, next) {
+export async function setupError (req, res, next) {
   if (req.locals.template === failedFileRequestTemplate || req.locals.template === failedUrlRequestTemplate) {
     req.locals.error = req.locals.requestData.getError()
   }

--- a/src/controllers/resultsController.js
+++ b/src/controllers/resultsController.js
@@ -48,7 +48,7 @@ export async function getRequestDataMiddleware (req, res, next) {
   }
 }
 
-export async function setupTemplate (req, res, next) {
+export function setupTemplate (req, res, next) {
   try {
     if (req.locals.requestData.isFailed()) {
       if (req.locals.requestData.getType() === 'check_file') {
@@ -83,7 +83,7 @@ export async function fetchResponseDetails (req, res, next) {
   next()
 }
 
-export async function setupTableParams (req, res, next) {
+export function setupTableParams (req, res, next) {
   if (req.locals.template !== failedFileRequestTemplate && req.locals.template !== failedUrlRequestTemplate) {
     const responseDetails = req.locals.responseDetails
     let rows = responseDetails.getRowsWithVerboseColumns(req.locals.requestData.hasErrors())
@@ -125,7 +125,7 @@ export async function setupTableParams (req, res, next) {
   next()
 }
 
-export async function setupErrorSummary (req, res, next) {
+export function setupErrorSummary (req, res, next) {
   try {
     if (req.locals.template !== failedFileRequestTemplate && req.locals.template !== failedUrlRequestTemplate) {
       req.locals.errorSummary = req.locals.requestData.getErrorSummary().map(message => {
@@ -141,7 +141,7 @@ export async function setupErrorSummary (req, res, next) {
   }
 }
 
-export async function setupError (req, res, next) {
+export function setupError (req, res, next) {
   try {
     if (req.locals.template === failedFileRequestTemplate || req.locals.template === failedUrlRequestTemplate) {
       req.locals.error = req.locals.requestData.getError()

--- a/src/controllers/resultsController.js
+++ b/src/controllers/resultsController.js
@@ -126,15 +126,19 @@ export async function setupTableParams (req, res, next) {
 }
 
 export async function setupErrorSummary (req, res, next) {
-  if (req.locals.template !== failedFileRequestTemplate && req.locals.template !== failedUrlRequestTemplate) {
-    req.locals.errorSummary = req.locals.requestData.getErrorSummary().map(message => {
-      return {
-        text: message,
-        href: ''
-      }
-    })
+  try {
+    if (req.locals.template !== failedFileRequestTemplate && req.locals.template !== failedUrlRequestTemplate) {
+      req.locals.errorSummary = req.locals.requestData.getErrorSummary().map(message => {
+        return {
+          text: message,
+          href: ''
+        }
+      })
+    }
+    next()
+  } catch (error) {
+    next(error, req, res, next)
   }
-  next()
 }
 
 export async function setupError (req, res, next) {

--- a/src/controllers/resultsController.js
+++ b/src/controllers/resultsController.js
@@ -69,13 +69,11 @@ export async function setupTemplate (req, res, next) {
 }
 
 export async function fetchResponseDetails (req, res, next) {
-  try {
+  if (req.locals.template !== failedFileRequestTemplate && req.locals.template !== failedUrlRequestTemplate) {
     const responseDetails = req.locals.template === errorsTemplate
       ? await req.locals.requestData.fetchResponseDetails(req.params.pageNumber, 50, 'error')
       : await req.locals.requestData.fetchResponseDetails(req.params.pageNumber)
     req.locals.responseDetails = responseDetails
-  } catch (error) {
-    return next(error, req, res, next)
   }
   next()
 }

--- a/src/controllers/resultsController.js
+++ b/src/controllers/resultsController.js
@@ -49,19 +49,23 @@ export async function getRequestDataMiddleware (req, res, next) {
 }
 
 export async function setupTemplate (req, res, next) {
-  if (req.locals.requestData.isFailed()) {
-    if (req.locals.requestData.getType() === 'check_file') {
-      req.locals.template = failedFileRequestTemplate
+  try {
+    if (req.locals.requestData.isFailed()) {
+      if (req.locals.requestData.getType() === 'check_file') {
+        req.locals.template = failedFileRequestTemplate
+      } else {
+        req.locals.template = failedUrlRequestTemplate
+      }
+    } else if (req.locals.requestData.hasErrors()) {
+      req.locals.template = errorsTemplate
     } else {
-      req.locals.template = failedUrlRequestTemplate
+      req.locals.template = noErrorsTemplate
     }
-  } else if (req.locals.requestData.hasErrors()) {
-    req.locals.template = errorsTemplate
-  } else {
-    req.locals.template = noErrorsTemplate
+    req.locals.requestParams = req.locals.requestData.getParams()
+    next()
+  } catch (error) {
+    next(error, req, res, next)
   }
-  req.locals.requestParams = req.locals.requestData.getParams()
-  next()
 }
 
 export async function fetchResponseDetails (req, res, next) {

--- a/src/controllers/resultsController.js
+++ b/src/controllers/resultsController.js
@@ -151,6 +151,5 @@ export async function setupError (req, res, next) {
     next(error, req, res, next)
   }
 }
-}
 
 export default ResultsController

--- a/src/controllers/resultsController.js
+++ b/src/controllers/resultsController.js
@@ -21,10 +21,7 @@ class ResultsController extends PageController {
 
   async locals (req, res, next) {
     try {
-      req.form.options = {
-        ...req.form.options,
-        ...req.locals
-      }
+      Object.assign(req.form.options, req.locals)
       super.locals(req, res, next)
     } catch (error) {
       next(error, req, res, next)

--- a/src/controllers/resultsController.js
+++ b/src/controllers/resultsController.js
@@ -142,10 +142,15 @@ export async function setupErrorSummary (req, res, next) {
 }
 
 export async function setupError (req, res, next) {
-  if (req.locals.template === failedFileRequestTemplate || req.locals.template === failedUrlRequestTemplate) {
-    req.locals.error = req.locals.requestData.getError()
+  try {
+    if (req.locals.template === failedFileRequestTemplate || req.locals.template === failedUrlRequestTemplate) {
+      req.locals.error = req.locals.requestData.getError()
+    }
+    next()
+  } catch (error) {
+    next(error, req, res, next)
   }
-  next()
+}
 }
 
 export default ResultsController

--- a/src/controllers/resultsController.js
+++ b/src/controllers/resultsController.js
@@ -65,11 +65,13 @@ export async function setupTemplate (req, res, next) {
 }
 
 export async function fetchResponseDetails (req, res, next) {
-  if (req.locals.template !== failedFileRequestTemplate && req.locals.template !== failedUrlRequestTemplate) {
+  try {
     const responseDetails = req.locals.template === errorsTemplate
       ? await req.locals.requestData.fetchResponseDetails(req.params.pageNumber, 50, 'error')
       : await req.locals.requestData.fetchResponseDetails(req.params.pageNumber)
     req.locals.responseDetails = responseDetails
+  } catch (error) {
+    return next(error, req, res, next)
   }
   next()
 }

--- a/src/controllers/resultsController.js
+++ b/src/controllers/resultsController.js
@@ -24,7 +24,7 @@ class ResultsController extends PageController {
       Object.assign(req.form.options, req.locals)
       super.locals(req, res, next)
     } catch (error) {
-      next(error, req, res, next)
+      next(error)
     }
   }
 
@@ -44,7 +44,7 @@ export async function getRequestDataMiddleware (req, res, next) {
     }
     next()
   } catch (error) {
-    next(error, req, res, next)
+    next(error)
   }
 }
 
@@ -64,7 +64,7 @@ export async function setupTemplate (req, res, next) {
     req.locals.requestParams = req.locals.requestData.getParams()
     next()
   } catch (e) {
-    next(e, req, res, next)
+    next(e)
   }
 }
 
@@ -77,7 +77,7 @@ export async function fetchResponseDetails (req, res, next) {
       req.locals.responseDetails = responseDetails
     }
   } catch (e) {
-    next(e, req, res, next)
+    next(e)
     return
   }
   next()
@@ -137,7 +137,7 @@ export async function setupErrorSummary (req, res, next) {
     }
     next()
   } catch (error) {
-    next(error, req, res, next)
+    next(error)
   }
 }
 
@@ -148,7 +148,7 @@ export async function setupError (req, res, next) {
     }
     next()
   } catch (error) {
-    next(error, req, res, next)
+    next(error)
   }
 }
 

--- a/test/unit/resultsController.test.js
+++ b/test/unit/resultsController.test.js
@@ -212,7 +212,7 @@ describe('ResultsController Class Tests', () => {
 
     await controller.locals(req, res, next)
 
-    expect(next).toHaveBeenCalledWith(error, req, res, next)
+    expect(next).toHaveBeenCalledWith(error)
   })
 
   it('should correctly determine if there are no errors', () => {

--- a/test/unit/resultsController.test.js
+++ b/test/unit/resultsController.test.js
@@ -1,213 +1,243 @@
-import ResultsController from '../../src/controllers/resultsController.js'
-import { describe, it, vi, expect, beforeEach } from 'vitest'
-import { initDatasetSlugToReadableNameFilter } from '../../src/utils/datasetSlugToReadableName.js'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import ResultsController, { fetchResponseDetails, getRequestDataMiddleware, setupError, setupErrorSummary, setupTableParams, setupTemplate } from '../../src/controllers/resultsController'
+import { getRequestData } from '../../src/services/asyncRequestApi'
+import prettifyColumnName from '../../src/filters/prettifyColumnName'
+import PageController from '../../src/controllers/pageController'
 
-describe('ResultsController', () => {
-  vi.mock('@/services/asyncRequestApi.js')
+vi.mock('../../src/services/asyncRequestApi', () => ({
+  getRequestData: vi.fn()
+}))
 
-  let asyncRequestApi
-  let resultsController
+vi.mock('../../src/filters/prettifyColumnName', () => ({
+  default: vi.fn()
+}))
 
-  const req = {
-    params: { id: 'testId' },
-    form: { options: {} },
-    session: { template: 'template' },
-    sessionModel: {
-      get: vi.fn().mockImplementation(key => {
-        const mockData = {
-          dataset: 'Dataset',
-          formFields: {}
-          // Add other potential keys
-        }
-        return mockData[key]
-      })
-    }
-  }
+const mockRequest = () => ({
+  params: { id: '123', pageNumber: '1' },
+  locals: {},
+  form: { options: {} }
+})
 
-  beforeEach(async () => {
-    asyncRequestApi = await import('@/services/asyncRequestApi')
+const mockResponse = () => ({
+  redirect: vi.fn()
+})
 
-    resultsController = new ResultsController({
-      route: '/results'
-    })
+const mockNext = vi.fn()
 
-    await initDatasetSlugToReadableNameFilter()
+describe('Middleware Tests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
   })
 
-  describe('locals', () => {
-    it('should set the template to the errors template if the result has errors', async () => {
-      const mockDetails = {
-        getErrorSummary: () => ['error summary'],
-        getColumns: () => ['columns'],
-        getFields: () => ['fields'],
-        getFieldMappings: () => 'fieldMappings',
-        getRowsWithVerboseColumns: () => ['verbose-columns'],
-        getGeometries: () => ['geometries'],
-        getPagination: () => 'pagination'
-      }
+  describe('getRequestDataMiddleware', () => {
+    it('should fetch request data and set it in req.locals', async () => {
+      const req = mockRequest()
+      const res = mockResponse()
+      const mockData = { isComplete: vi.fn(() => true) }
 
-      const mockResult = {
-        isFailed: () => false,
-        getError: () => 'error',
-        hasErrors: () => true,
-        isComplete: () => true,
-        getParams: () => ('params'),
-        getId: () => 'fake_id',
-        fetchResponseDetails: () => mockDetails,
-        getErrorSummary: () => ['error summary']
-      }
+      getRequestData.mockResolvedValue(mockData)
 
-      asyncRequestApi.getRequestData = vi.fn().mockResolvedValue(mockResult)
+      await getRequestDataMiddleware(req, res, mockNext)
 
-      await resultsController.locals(req, {}, () => {})
-      expect(req.form.options.template).toBe('results/errors')
+      expect(getRequestData).toHaveBeenCalledWith(req.params.id)
+      expect(req.locals.requestData).toEqual(mockData)
+      expect(mockNext).toHaveBeenCalled()
     })
 
-    it('should set the template to the no-errors template if the result has no errors', async () => {
-      const mockDetails = {
-        getErrorSummary: () => ['error summary'],
-        getColumns: () => ['columns'],
-        getFields: () => ['fields'],
-        getFieldMappings: () => 'fieldMappings',
-        getRowsWithVerboseColumns: () => ['verbose-columns'],
-        getGeometries: () => ['geometries'],
-        getPagination: () => 'pagination'
-      }
+    it('should redirect if request data is incomplete', async () => {
+      const req = mockRequest()
+      const res = mockResponse()
+      const mockData = { isComplete: vi.fn(() => false) }
 
-      const mockResult = {
-        isFailed: () => false,
-        getError: () => 'error',
-        hasErrors: () => false,
-        isComplete: () => true,
-        getParams: () => ('params'),
-        getId: () => 'fake_id',
-        fetchResponseDetails: () => mockDetails,
-        getErrorSummary: () => ['error summary']
-      }
-      asyncRequestApi.getRequestData = vi.fn().mockResolvedValue(mockResult)
+      getRequestData.mockResolvedValue(mockData)
 
-      await resultsController.locals(req, {}, () => {})
-      expect(req.form.options.template).toBe('results/no-errors')
-    })
+      await getRequestDataMiddleware(req, res, mockNext)
 
-    it('should correctly set template variables', async () => {
-      const mockResult = {
-        isComplete: () => true,
-        isFailed: () => false,
-        getParams: () => 'params',
-        getErrorSummary: () => (['error summary']),
-
-        getColumns: () => (['columns']),
-        getRowsWithVerboseColumns: () => (['verbose-columns']),
-        getFields: () => (['fields']),
-        hasErrors: () => false,
-        fetchResponseDetails: () => ({
-          getRowsWithVerboseColumns: () => [
-            {
-              columns: {},
-              fields: ['mock field'],
-              values: ['mock value']
-            }
-          ],
-          getColumns: () => ['mock Columns'],
-          getFields: () => ['mock fields'],
-          getFieldMappings: () => ({ fields: 'geometries' }),
-          getGeometries: () => ['geometries'],
-          getPagination: () => 'pagination'
-        })
-      }
-
-      const res = { redirect: vi.fn() }
-      asyncRequestApi.getRequestData = vi.fn().mockResolvedValue(mockResult)
-
-      await resultsController.locals(req, res, () => {})
-
-      expect(req.form.options.data).toBe(mockResult)
-      expect(req.form.options).toStrictEqual({
-        data: mockResult,
-        tableParams: {
-          columns: ['Mock Columns'],
-          fields: ['mock fields'],
-          rows: [{
-            columns: {},
-            fields: ['mock field'],
-            values: ['mock value']
-          }]
-        },
-        datasetName: req.sessionModel.get('dataset'),
-
-        errorSummary: [{ text: 'error summary', href: '' }],
-        mappings: { fields: 'geometries' },
-        geometries: ['geometries'],
-        pagination: 'pagination',
-        requestParams: 'params',
-        template: 'results/no-errors',
-        id: req.params.id,
-        lastPage: `/check/status/${req.params.id}`
-      })
-    })
-
-    it('should redirect to the status page if the result is not complete', async () => {
-      const mockResult = { isFailed: () => true, hasErrors: () => false, isComplete: () => false }
-      asyncRequestApi.getRequestData = vi.fn().mockResolvedValue(mockResult)
-
-      const res = { redirect: vi.fn() }
-      await resultsController.locals(req, res, () => {})
       expect(res.redirect).toHaveBeenCalledWith(`/check/status/${req.params.id}`)
+      expect(mockNext).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('setupTemplate', () => {
+    it('should set the appropriate template based on request data state', async () => {
+      const req = mockRequest()
+      const res = mockResponse()
+
+      req.locals.requestData = {
+        isFailed: vi.fn(() => true),
+        getType: vi.fn(() => 'check_file'),
+        hasErrors: vi.fn(() => false),
+        getParams: vi.fn(() => ({}))
+      }
+
+      await setupTemplate(req, res, mockNext)
+
+      expect(req.locals.template).toEqual('results/failedFileRequest')
+      expect(mockNext).toHaveBeenCalled()
+    })
+  })
+
+  describe('fetchResponseDetails', () => {
+    it('should fetch response details and set it in req.locals', async () => {
+      const req = mockRequest()
+      const res = mockResponse()
+
+      req.locals.template = 'results/errors'
+      req.locals.requestData = {
+        fetchResponseDetails: vi.fn().mockResolvedValue({ data: 'mockData' })
+      }
+
+      await fetchResponseDetails(req, res, mockNext)
+
+      expect(req.locals.responseDetails).toEqual({ data: 'mockData' })
+      expect(mockNext).toHaveBeenCalled()
     })
 
-    it("should call next with a 404 error if the result wasn't found", async () => {
-      asyncRequestApi.getRequestData = vi.fn().mockImplementation(() => {
-        throw new Error('Request not found', { message: 'Request not found', status: 404 })
+    it('should not fetch response details if the template indicates failure', async () => {
+      const req = mockRequest()
+      const res = mockResponse()
+
+      req.locals.template = 'results/failedFileRequest'
+
+      await fetchResponseDetails(req, res, mockNext)
+
+      expect(req.locals.responseDetails).toBeUndefined()
+      expect(mockNext).toHaveBeenCalled()
+    })
+  })
+
+  describe('setupTableParams', () => {
+    it('should set table params, mappings, geometries, and pagination in req.locals', async () => {
+      const req = mockRequest()
+      const res = mockResponse()
+
+      req.locals.template = 'results/no-errors'
+      req.locals.requestData = {
+        hasErrors: vi.fn(() => false)
+      }
+      req.locals.responseDetails = {
+        getRowsWithVerboseColumns: vi.fn(() => [{ columns: {}, data: 'rowData' }]),
+        getColumns: vi.fn(() => ['column1', 'column2']),
+        getFields: vi.fn(() => ['field1', 'field2']),
+        getFieldMappings: vi.fn(() => 'mockMappings'),
+        getGeometries: vi.fn(() => 'mockGeometries'),
+        getPagination: vi.fn(() => 'mockPagination')
+      }
+
+      prettifyColumnName.mockImplementation((col) => `Pretty ${col}`)
+
+      await setupTableParams(req, res, mockNext)
+
+      expect(req.locals.tableParams).toEqual({
+        columns: ['Pretty column1', 'Pretty column2'],
+        rows: [{ columns: {}, data: 'rowData' }],
+        fields: ['field1', 'field2']
       })
+      expect(req.locals.mappings).toEqual('mockMappings')
+      expect(req.locals.geometries).toEqual('mockGeometries')
+      expect(req.locals.pagination).toEqual('mockPagination')
+      expect(mockNext).toHaveBeenCalled()
+    })
+  })
 
-      const nextMock = vi.fn()
-      await resultsController.locals(req, {}, nextMock)
-      expect(nextMock).toHaveBeenCalledWith(new Error('Request not found', { message: 'Request not found', status: 404 }), req, {}, nextMock)
+  describe('setupErrorSummary', () => {
+    it('should set error summary in req.locals', async () => {
+      const req = mockRequest()
+      const res = mockResponse()
+
+      req.locals.template = 'results/errors'
+      req.locals.requestData = {
+        getErrorSummary: vi.fn(() => ['Error1', 'Error2'])
+      }
+
+      await setupErrorSummary(req, res, mockNext)
+
+      expect(req.locals.errorSummary).toEqual([
+        { text: 'Error1', href: '' },
+        { text: 'Error2', href: '' }
+      ])
+      expect(mockNext).toHaveBeenCalled()
+    })
+  })
+
+  describe('setupError', () => {
+    it('should set error in req.locals if the template indicates failure', async () => {
+      const req = mockRequest()
+      const res = mockResponse()
+
+      req.locals.template = 'results/failedFileRequest'
+      req.locals.requestData = { getError: vi.fn(() => 'mockError') }
+
+      await setupError(req, res, mockNext)
+
+      expect(req.locals.error).toEqual('mockError')
+      expect(mockNext).toHaveBeenCalled()
+    })
+  })
+})
+
+describe('ResultsController Class Tests', () => {
+  let controller
+  let req
+  let res
+
+  beforeEach(() => {
+    controller = new ResultsController({ route: '/results' })
+    req = mockRequest()
+    res = mockResponse()
+  })
+
+  it('should extend PageController', () => {
+    expect(controller).toBeInstanceOf(PageController)
+  })
+
+  it('should call super.locals and merge req.locals into req.form.options', async () => {
+    const next = vi.fn()
+    req.locals = { key: 'value' }
+
+    await controller.locals(req, res, next)
+
+    expect(req.form.options.key).toEqual('value')
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should handle errors in the locals method', async () => {
+    const next = vi.fn()
+    const error = new Error('Test Error')
+
+    // Mock the parent class's locals method to throw an error
+    vi.spyOn(PageController.prototype, 'locals').mockImplementation(() => {
+      throw error
     })
 
-    it('should call next with a 500 error if the result processing errored', async () => {
-      asyncRequestApi.getRequestData = vi.fn().mockImplementation(() => {
-        throw new Error('Unexpected error', { message: 'Unexpected error', status: 500 })
-      })
+    await controller.locals(req, res, next)
 
-      const nextMock = vi.fn()
-      await resultsController.locals(req, {}, nextMock)
-      expect(nextMock).toHaveBeenCalledWith(new Error('Unexpected error', { message: 'Unexpected error', status: 500 }), req, {}, nextMock)
-    })
+    expect(next).toHaveBeenCalledWith(error, req, res, next)
+  })
 
-    it('should set the template to the errors template if the result has errors', async () => {
-      const mockResult = { hasErrors: () => true, isFailed: () => false, isComplete: () => true }
-      asyncRequestApi.getRequestData = vi.fn().mockResolvedValue(mockResult)
+  it('should correctly determine if there are no errors', () => {
+    req.form.options = {
+      data: {
+        hasErrors: vi.fn(() => false)
+      }
+    }
 
-      await resultsController.locals(req, {}, () => {})
-      expect(req.form.options.template).toBe('results/errors')
-      expect(resultsController.noErrors(req)).toBe(false)
-    })
+    const result = controller.noErrors(req, res, mockNext)
 
-    it('should set the template to the no-errors template if the result has no errors', async () => {
-      const mockResult = { hasErrors: () => false, isFailed: () => false, isComplete: () => true }
-      asyncRequestApi.getRequestData = vi.fn().mockResolvedValue(mockResult)
+    expect(result).toBe(true)
+    expect(req.form.options.data.hasErrors).toHaveBeenCalled()
+  })
 
-      await resultsController.locals(req, {}, () => {})
-      expect(req.form.options.template).toBe('results/no-errors')
-      expect(resultsController.noErrors(req)).toBe(true)
-    })
+  it('should return false if there are errors', () => {
+    req.form.options = {
+      data: {
+        hasErrors: vi.fn(() => true)
+      }
+    }
 
-    it('should set the template to the failedFileRequest template if the result is failed for a file check', async () => {
-      const mockResult = { isFailed: () => true, hasErrors: () => false, isComplete: () => true, getType: () => 'check_file' }
-      asyncRequestApi.getRequestData = vi.fn().mockResolvedValue(mockResult)
+    const result = controller.noErrors(req, res, mockNext)
 
-      await resultsController.locals(req, {}, () => {})
-      expect(req.form.options.template).toBe('results/failedFileRequest')
-    })
-
-    it('should set the template to the failedUrlRequest template if the result is failed for a url check', async () => {
-      const mockResult = { isFailed: () => true, hasErrors: () => false, isComplete: () => true, getType: () => 'check_url' }
-      asyncRequestApi.getRequestData = vi.fn().mockResolvedValue(mockResult)
-
-      await resultsController.locals(req, {}, () => {})
-      expect(req.form.options.template).toBe('results/failedUrlRequest')
-    })
+    expect(result).toBe(false)
+    expect(req.form.options.data.hasErrors).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- Refactor

## Description
Refactor the results hmpo controller to split the locals method up into several middleware. this is in anticipation of the changes to this page for #785 

## Related Tickets & Documents
- Ticket Link: #830 

## QA Instructions, Screenshots, Recordings
- the content should not have changed at all. to test this. simply run through the check tool and ensure all still works as before

## Added/updated tests?
- Yes

## QA sign off
- [ ] Code has been checked and approved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Refactor**
  - Restructured the results controller to improve code modularity.
  - Introduced middleware functions for handling request processing.
  - Simplified request data management and error handling.

- **New Features**
  - Added a new `PageController` class to enhance session handling and logging.

- **Tests**
  - Updated testing suite to cover new middleware functions.
  - Expanded test coverage for error handling and request management.

These changes optimise the application's request handling mechanism, making the code more maintainable and easier to understand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->