### PR TITLE
fix: ODP membership status

### DIFF
--- a/src/middleware/overview.middleware.js
+++ b/src/middleware/overview.middleware.js
@@ -226,6 +226,12 @@ export function prepareDatasetObjects (req, res, next) {
  */
 export function prepareOverviewTemplateParams (req, res, next) {
   const { orgInfo: organisation, provisions, datasets } = req
+
+  const provisionData = new Map()
+  for (const provision of provisions ?? []) {
+    provisionData.set(provision.dataset, provision)
+  }
+
   // add in any of the missing key 8 datasets
   const keys = new Set(datasets.map(d => d.dataset))
   availableDatasets.forEach((dataset) => {
@@ -241,10 +247,7 @@ export function prepareOverviewTemplateParams (req, res, next) {
     }
   })
 
-  const provisionData = new Map()
-  for (const provision of provisions ?? []) {
-    provisionData.set(provision.dataset, provision)
-  }
+  const isOPDMember = provisions.findIndex((p) => p.project === 'open-digital-planning') >= 0
 
   const totalDatasets = datasets.length
   const [datasetsWithEndpoints, datasetsWithIssues, datasetsWithErrors] = datasets.reduce(orgStatsReducer, [0, 0, 0])
@@ -269,7 +272,8 @@ export function prepareOverviewTemplateParams (req, res, next) {
     totalDatasets,
     datasetsWithEndpoints,
     datasetsWithIssues,
-    datasetsWithErrors
+    datasetsWithErrors,
+    isOPDMember
   }
 
   next()

--- a/src/routes/schemas.js
+++ b/src/routes/schemas.js
@@ -130,7 +130,8 @@ export const OrgOverviewPage = v.strictObject({
   totalDatasets: v.integer(),
   datasetsWithEndpoints: v.integer(),
   datasetsWithIssues: v.integer(),
-  datasetsWithErrors: v.integer()
+  datasetsWithErrors: v.integer(),
+  isOPDMember: v.boolean()
 })
 
 export const OrgFindPage = v.strictObject({

--- a/src/views/organisations/overview.html
+++ b/src/views/organisations/overview.html
@@ -139,7 +139,7 @@
   {% if datasets.other.length > 0 %}
     <div data-testid="datasetsOdpMandatory">
       <h2 class="govuk-heading-m">Datasets organisations in Open Digital Planning programme must provide</h2>
-      {% if datasets.other[0].project === 'open-digital-planning' %}
+      {% if isOPDMember %}
         <p class="org-membership-info">{{ organisation.name}} is a member of the Open Digital Planning programme.</p>
       {% else %}
         <p class="org-membership-info">{{ organisation.name}} is not a member of the Open Digital Planning programme.</p>

--- a/test/unit/middleware/overview.middleware.test.js
+++ b/test/unit/middleware/overview.middleware.test.js
@@ -93,7 +93,8 @@ describe('overview.middleware', () => {
         totalDatasets: 4,
         datasetsWithEndpoints: 2,
         datasetsWithIssues: 1,
-        datasetsWithErrors: 2
+        datasetsWithErrors: 2,
+        isOPDMember: true
       }
 
       expect(req.templateParams).toEqual(expectedTemplateParams)
@@ -142,7 +143,8 @@ describe('overview.middleware', () => {
         totalDatasets: 3,
         datasetsWithEndpoints: 2,
         datasetsWithIssues: 1,
-        datasetsWithErrors: 1
+        datasetsWithErrors: 1,
+        isOPDMember: false
       }
 
       getOverview(req, res, next)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

The ODP membership status text on LPA overview pages is incorrect. Code that added project info to the datasets was erroneously removed in #730. Adding it back (with slight change). 

## Related Tickets & Documents

- Related Issue #730 

## QA Instructions, Screenshots, Recordings

Going to the LPA overview pages, they should now correctly indicate whether the organisation is part of the programme or not.

## Added/updated tests?

- [x] Yes

## QA sign off
- [ ] Code has been checked and approved
- [ ] Design has been checked and approved
- [ ] Product and business logic has been checked and proved



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added a new `isOPDMember` flag to indicate Open Digital Planning programme membership

- **Improvements**
	- Updated organisation overview page to use a more direct method of checking programme membership
	- Refined middleware logic for handling organisation data

- **Testing**
	- Enhanced unit tests to validate new membership feature and error card rendering

These changes improve the visibility and handling of Open Digital Planning programme membership information across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->