### PR TITLE
fix: invalid data range

### DIFF
--- a/src/middleware/common.middleware.js
+++ b/src/middleware/common.middleware.js
@@ -8,6 +8,7 @@ import * as v from 'valibot'
 import { pagination } from '../utils/pagination.js'
 import datasette from '../services/datasette.js'
 import { errorTemplateContext, MiddlewareError } from '../utils/errors.js'
+import { dataRangeParams } from '../routes/schemas.js'
 
 /**
  * Middleware. Set `req.handlerName` to a string that will identify
@@ -113,14 +114,10 @@ export const getDatasetTaskListError = renderTemplate({
 export const show404IfPageNumberNotInRange = (req, res, next) => {
   const { dataRange } = req
   const { pageNumber } = req.parsedParams
-
-  if (!dataRange || !dataRange.maxPageNumber || isNaN(dataRange.maxPageNumber)) {
-    const error = new Error('invalid req.dataRange object')
-    return next(error)
-  }
+  v.parse(dataRangeParams, dataRange)
 
   if (pageNumber > dataRange.maxPageNumber || pageNumber < 1) {
-    const error = new MiddlewareError('page number not in range', 404)
+    const error = new MiddlewareError(`page number ${pageNumber} not in range [1, ${dataRange.maxPageNumber}]`, 404)
     return next(error)
   }
   next()
@@ -130,13 +127,13 @@ export const createPaginationTemplateParams = (req, res, next) => {
   const { pageNumber } = req.parsedParams
   const { baseSubpath, dataRange } = req
 
-  if (dataRange.maxPageNumber <= 1) {
-    return next()
-  }
-
   if (isNaN(pageNumber) || pageNumber < 1) {
     const error = new Error('Invalid page number')
     return next(error)
+  }
+
+  if (dataRange.maxPageNumber <= 1) {
+    return next()
   }
 
   /**
@@ -638,29 +635,34 @@ export const getSetBaseSubPath = (additionalParts = []) => (req, res, next) => {
   next()
 }
 
-export const getSetDataRange = (pageLength) => (req, res, next) => {
-  const { recordCount } = req
-  const { pageNumber } = req.parsedParams
+/**
+ * @param {number} pageLength
+ * @returns {(req, res, next) => void }
+ */
+export const getSetDataRange = (pageLength) => {
+  v.parse(v.pipe(v.number(), v.integer(), v.minValue(1)), pageLength)
 
-  if (typeof recordCount !== 'number' || recordCount < 0) {
-    return next(new Error('Invalid record count'))
-  }
-  if (typeof pageNumber !== 'number' || pageNumber < 1) {
-    return next(new Error('Invalid page number'))
-  }
-  if (typeof pageLength !== 'number' || pageLength < 1) {
-    return next(new Error('Invalid page length'))
-  }
+  return (req, res, next) => {
+    const { pageNumber } = req.parsedParams
 
-  req.dataRange = {
-    minRow: (pageNumber - 1) * pageLength,
-    maxRow: Math.min((pageNumber - 1) * pageLength + pageLength, recordCount),
-    totalRows: recordCount,
-    maxPageNumber: Math.ceil(recordCount / pageLength),
-    pageLength,
-    offset: (pageNumber - 1) * pageLength
+    let recordCount = req.recordCount
+    if (typeof recordCount !== 'number' || recordCount < 0) {
+      logger.warn(`Invalid record count: ${recordCount}`, { type: types.App, recordCount, endpoint: req.originalUrl })
+      recordCount = 0
+    }
+
+    req.dataRange = v.parse(dataRangeParams, {
+      minRow: (pageNumber - 1) * pageLength,
+      maxRow: Math.min((pageNumber - 1) * pageLength + pageLength, recordCount),
+      totalRows: recordCount,
+      // pageNumber starts with 1, so we maxPageNumber to start with 1
+      maxPageNumber: Math.max(Math.ceil(recordCount / pageLength), 1),
+      pageLength,
+      offset: (pageNumber - 1) * pageLength
+    })
+
+    next()
   }
-  next()
 }
 
 export function getErrorSummaryItems (req, res, next) {

--- a/src/middleware/entryIssueDetails.middleware.js
+++ b/src/middleware/entryIssueDetails.middleware.js
@@ -117,6 +117,15 @@ export const prepareEntry = (req, res, next) => {
   next()
 }
 
+const show404ifNoIssues = (req, res, next) => {
+  if (req.recordCount === 0) {
+    // e.g. we got here via old link and there are no issues anymore
+    next(new MiddlewareError('Issue count is zero for dataset', 404))
+  } else {
+    next()
+  }
+}
+
 export const getIssueDetails = renderTemplate({
   templateParams: (req) => req.templateParams,
   template: 'organisations/issueDetails.html',
@@ -132,6 +141,7 @@ export default [
   addResourceMetaDataToResources,
   fetchIssueCount,
   setRecordCount,
+  show404ifNoIssues,
   getSetDataRange(1),
   fetchEntryIssues,
   show404IfPageNumberNotInRange,

--- a/src/routes/schemas.js
+++ b/src/routes/schemas.js
@@ -50,13 +50,13 @@ export const PaginationParams = v.optional(v.strictObject({
   ]))
 }))
 
-export const dataRangeParams = v.strictObject({
-  minRow: v.integer(),
-  maxRow: v.integer(),
-  totalRows: v.integer(),
-  maxPageNumber: v.optional(v.integer()),
-  pageLength: v.optional(v.integer()),
-  offset: v.optional(v.integer())
+export const dataRangeParams = v.object({
+  minRow: v.pipe(v.number(), v.integer(), v.minValue(0)),
+  maxRow: v.pipe(v.number(), v.integer(), v.minValue(0)),
+  totalRows: v.pipe(v.number(), v.integer(), v.minValue(0)),
+  maxPageNumber: v.pipe(v.number(), v.integer(), v.minValue(0)),
+  pageLength: v.pipe(v.number(), v.integer(), v.minValue(1)),
+  offset: v.pipe(v.number(), v.integer(), v.minValue(0))
 })
 
 export const errorSummaryParams = v.strictObject({

--- a/test/unit/middleware/entityIssueDetails.middleware.test.js
+++ b/test/unit/middleware/entityIssueDetails.middleware.test.js
@@ -183,7 +183,10 @@ describe('issueDetails.middleware.js', () => {
           dataRange: {
             minRow: 0,
             maxRow: 50,
-            totalRows: 150
+            totalRows: 150,
+            maxPageNumber: 3,
+            pageLength: 50,
+            offset: 0
           }
         }
       }

--- a/test/unit/middleware/entryIssueDetails.middleware.test.js
+++ b/test/unit/middleware/entryIssueDetails.middleware.test.js
@@ -210,7 +210,10 @@ describe('entryIssueDetails.middleware.test.js', () => {
           dataRange: {
             minRow: 0,
             maxRow: 50,
-            totalRows: 150
+            totalRows: 150,
+            maxPageNumber: 3,
+            pageLength: 50,
+            offset: 0
           }
         }
       }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Bug Fix

## Description

Fixes issues with incorrect handling of `dataRange` object by:
- putting schema checks in the right places
- not relying on the generic 404 middleware

## Related Tickets & Documents

- Closes #764

## QA Instructions, Screenshots, Recordings

production: this [link](https://submit.planning.data.gov.uk/organisations/local-authority:BST/brownfield-land/invalid%20organisation/organisation/entry) causes trouble

same in preview instance: [link](https://submit-pr-839.herokuapp.com/organisations/local-authority:BST/brownfield-land/invalid%20organisation/organisation/entry) results in 404

## Added/updated tests?

- [x] Yes

## QA sign off (not applicable)

- ~~[ ] Code has been checked and approved~~
- ~~[ ] Design has been checked and approved~~
- ~~[ ] Product and business logic has been checked and proved~~
