### PR TITLE
update headers on check tool to display org and dataset

### DIFF
--- a/src/controllers/pageController.js
+++ b/src/controllers/pageController.js
@@ -48,7 +48,7 @@ class PageController extends Controller {
         req.form.options.deepLink = deepLinkInfo
         req.form.options.dataset = deepLinkInfo.dataset
         req.form.options.datasetName = deepLinkInfo.datasetName
-        req.form.options.lpa = deepLinkInfo.lpa
+        req.form.options.lpa = deepLinkInfo.lpa || deepLinkInfo.orgName
         req.form.options.orgId = deepLinkInfo.orgId
         backLink = wizardBackLink(req.originalUrl, deepLinkInfo)
       }

--- a/src/views/check/geometry-type.html
+++ b/src/views/check/geometry-type.html
@@ -39,10 +39,7 @@
         }) }}
       {% endif %}
       <form novalidate method="post">
-
-        {% if options.datasetName %}
-          {{ datasetBanner(options.datasetName) }}
-        {% endif %}
+        {{ datasetBanner(options.orgId, options.datasetName) }}
 
         {{ govukRadios({
           name: "geomType",

--- a/src/views/check/geometry-type.html
+++ b/src/views/check/geometry-type.html
@@ -39,7 +39,7 @@
         }) }}
       {% endif %}
       <form novalidate method="post">
-        {{ datasetBanner(options.orgId, options.datasetName) }}
+        {{ datasetBanner(options.lpa, options.datasetName) }}
 
         {{ govukRadios({
           name: "geomType",

--- a/src/views/check/results/results.html
+++ b/src/views/check/results/results.html
@@ -44,12 +44,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
-      {% if options.datasetName %}
-        {{ datasetBanner(options.datasetName) }}
-      {% else %}
-        <span class="govuk-caption-l">{{options.requestParams.dataset}}</span>
-      {% endif %}
+      {{ datasetBanner(options.orgId, options.datasetName or options.requestParams.dataset) }}
 
       <h1 class="govuk-heading-l">
         {{pageName}}

--- a/src/views/check/results/results.html
+++ b/src/views/check/results/results.html
@@ -44,7 +44,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {{ datasetBanner(options.orgId, options.datasetName or options.requestParams.dataset) }}
+      {{ datasetBanner(options.lpa, options.datasetName or options.requestParams.dataset) }}
 
       <h1 class="govuk-heading-l">
         {{pageName}}

--- a/src/views/check/statusPage/status.html
+++ b/src/views/check/statusPage/status.html
@@ -30,7 +30,7 @@
 {% block content %}
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds" aria-live="assertive">
-      {{ datasetBanner(options.orgId, options.datasetName) }}
+      {{ datasetBanner(options.lpa, options.datasetName) }}
       
       {{ pageContent }}
     </div>

--- a/src/views/check/statusPage/status.html
+++ b/src/views/check/statusPage/status.html
@@ -30,9 +30,8 @@
 {% block content %}
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds" aria-live="assertive">
-      {% if options.datasetName %}
-        {{ datasetBanner(options.datasetName) }}
-      {% endif %}
+      {{ datasetBanner(options.orgId, options.datasetName) }}
+      
       {{ pageContent }}
     </div>
 

--- a/src/views/check/upload-method.html
+++ b/src/views/check/upload-method.html
@@ -39,7 +39,7 @@
         }) }}
       {% endif %}
       <form novalidate method="post">
-        {{ datasetBanner(options.orgId, options.datasetName) }}
+        {{ datasetBanner(options.lpa, options.datasetName) }}
 
         {{ govukRadios({
           name: "upload-method",

--- a/src/views/check/upload-method.html
+++ b/src/views/check/upload-method.html
@@ -39,9 +39,7 @@
         }) }}
       {% endif %}
       <form novalidate method="post">
-        {% if options.datasetName %}
-          {{ datasetBanner(options.datasetName) }}
-        {% endif %}
+        {{ datasetBanner(options.orgId, options.datasetName) }}
 
         {{ govukRadios({
           name: "upload-method",

--- a/src/views/check/upload.html
+++ b/src/views/check/upload.html
@@ -46,7 +46,7 @@
         }) }}
       {% endif %}
       <form novalidate method="post" enctype="multipart/form-data">
-        {{ datasetBanner(options.orgId, options.datasetName) }}
+        {{ datasetBanner(options.lpa, options.datasetName) }}
 
         {{ govukFileUpload({
           id: "datafile",

--- a/src/views/check/upload.html
+++ b/src/views/check/upload.html
@@ -46,10 +46,7 @@
         }) }}
       {% endif %}
       <form novalidate method="post" enctype="multipart/form-data">
-
-        {% if options.datasetName %}
-          {{ datasetBanner(options.datasetName) }}
-        {% endif %}
+        {{ datasetBanner(options.orgId, options.datasetName) }}
 
         {{ govukFileUpload({
           id: "datafile",

--- a/src/views/check/url.html
+++ b/src/views/check/url.html
@@ -49,9 +49,8 @@
         }) }}
       {% endif %}
       <form novalidate method="post">
-        {% if options.datasetName %}
-          {{ datasetBanner(options.datasetName) }}
-        {% endif %}
+        {{ datasetBanner(options.orgId, options.datasetName) }}
+        
         {{ govukInput({
           id: "url",
           name: "url",

--- a/src/views/check/url.html
+++ b/src/views/check/url.html
@@ -49,7 +49,7 @@
         }) }}
       {% endif %}
       <form novalidate method="post">
-        {{ datasetBanner(options.orgId, options.datasetName) }}
+        {{ datasetBanner(options.lpa, options.datasetName) }}
         
         {{ govukInput({
           id: "url",

--- a/src/views/components/dataset-banner.html
+++ b/src/views/components/dataset-banner.html
@@ -1,3 +1,11 @@
-{% macro datasetBanner(datasetName) %}
-<span class="govuk-caption-xl">{{ datasetName | datasetSlugToReadableName }}</span>
+{% macro datasetBanner(orgName, datasetName) %}
+  <span class="govuk-caption-xl">
+    {% if orgName and datasetName %}
+      {{ orgName }} — {{ datasetName | datasetSlugToReadableName }}
+    {% elif orgName %}
+      {{ orgName }}
+    {% elif datasetName %}
+      {{ datasetName | datasetSlugToReadableName }}
+    {% endif %}
+  </span>
 {% endmacro %}


### PR DESCRIPTION
## Preview Link
https://submit-pr-856.herokuapp.com/

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
now display org and dataset in check heading similar to how submit does

## Related Tickets & Documents
- Ticket Link #856 

## QA Instructions, Screenshots, Recordings
### Before
<img width="503" alt="image" src="https://github.com/user-attachments/assets/cbbae120-9bf6-45f6-9fc6-e6cca061cd74" />

### After
<img width="496" alt="image" src="https://github.com/user-attachments/assets/bf3a65d1-33ad-4760-85c2-369e511d8fea" />

## Added/updated tests?
- No

## QA sign off
- [ ] Code has been checked and approved
- [x] Design has been checked and approved
- [x] Product and business logic has been checked and proved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced dataset banner display now uniformly shows both your organisation identifier and dataset details across various pages. This update provides a clearer, more consistent view by presenting combined organisation and dataset information regardless of whether dataset details are fully available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->