### PR TITLE
update datasette to get url from config and use dev url on dev

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -25,6 +25,7 @@ serviceNames: {
     check: 'Submit and update your planning data',
     manage: 'Submit and update your planning data'
 }
+datasetteUrl: 'https://datasette.planning.data.gov.uk'
 checkService:
     # used as User-Agent header when checking the accessibility
     # of user supplied URLs

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -5,6 +5,7 @@ aws: {
     region: eu-west-2,
     bucket: 'development-pub-async-request-files',
 }
+datasetteUrl: https://datasette.development.planning.data.gov.uk
 redis: {
     secure: true,
     host: 'development-pub-async-redis-3dqynz.serverless.euw2.cache.amazonaws.com',

--- a/src/services/datasette.js
+++ b/src/services/datasette.js
@@ -1,8 +1,7 @@
 import axios from 'axios'
 import logger from '../utils/logger.js'
 import { types } from '../utils/logging.js'
-
-const datasetteUrl = 'https://datasette.planning.data.gov.uk'
+import config from '../../config/index.js'
 
 export default {
   /**
@@ -17,7 +16,7 @@ export default {
  */
   runQuery: async (query, database = 'digital-land') => {
     const encodedQuery = encodeURIComponent(query)
-    const url = `${datasetteUrl}/${database}.json?sql=${encodedQuery}`
+    const url = `${config.datasetteUrl}/${database}.json?sql=${encodedQuery}`
 
     try {
       const response = await axios.get(url)
@@ -26,7 +25,7 @@ export default {
         formattedData: formatData(response.data.columns, response.data.rows)
       }
     } catch (error) {
-      logger.warn({ message: `runQuery(): ${error.message}`, type: types.App, query, datasetteUrl, database })
+      logger.warn({ message: `runQuery(): ${error.message}`, type: types.App, query, datasetteUrl: config.datasetteUrl, database })
       throw error
     }
   }


### PR DESCRIPTION

https://submit-pr-[PR_NUMBER].herokuapp.com/

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Now we send datasette queries to different datasette environments based on our environment

## Ticket
https://github.com/orgs/digital-land/projects/7/views/15?pane=issue&itemId=97412552

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a configurable Datasette endpoint for both production and development setups, enhancing access to Datasette resources.
	- Updated the configuration to provide a more flexible and customisable service integration.

- **Refactor**
	- Transitioned from a fixed, hardcoded URL to the new configuration option.
	- Marked an older service identifier as deprecated in favour of a more descriptive service mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->