### PR TITLE
check tool: issue details page

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -102,3 +102,8 @@ features:
     enabled: false
   submitEndpointForm:
     enabled: false
+  checkIssueDetailsPage:
+    # https://github.com/digital-land/submit/issues/786
+    # enabling this feature will cause the results page to present 
+    # links to individual issue pages
+    enabled: true

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -23,3 +23,8 @@ features:
     enabled: false
   submitEndpointForm:
     enabled: false
+  checkIssueDetailsPage:
+    # https://github.com/digital-land/submit/issues/786
+    # enabling this feature will cause the results page to present 
+    # links to individual issue pages
+    enabled: false

--- a/performance-test/locustfile.py
+++ b/performance-test/locustfile.py
@@ -59,7 +59,7 @@ class DataProviderUser(FastHttpUser):
         logging.info(f"Request with id: {request_id}, got status: {result.json().get('status')}")
 
         if result.json().get('status') == "COMPLETE":
-            self._get(path=f"/results/{request_id}/0", name="/results/[request_id]")
+            self._get(path=f"/results/{request_id}/1", name="/results/[request_id]")
 
     def _visit_start_page(self):
         return self._get(path='/')

--- a/src/assets/scss/index.scss
+++ b/src/assets/scss/index.scss
@@ -223,3 +223,6 @@ code * {
 }
 
 .schema-issue p { padding: 0; margin: 0}
+.govuk-error-summary span.column-name {
+  font-weight: bold;
+}

--- a/src/controllers/ShareResultsController.js
+++ b/src/controllers/ShareResultsController.js
@@ -23,7 +23,7 @@ class ShareResultsController extends PageController {
   }
 
   generateResultsLink (id) {
-    return `${config.url}check/results/${id}/0`
+    return `${config.url}check/results/${id}/1`
   }
 }
 

--- a/src/controllers/issueDetailsController.js
+++ b/src/controllers/issueDetailsController.js
@@ -1,0 +1,69 @@
+import logger from '../utils/logger.js'
+import PageController from './pageController.js'
+import * as results from './resultsController.js'
+import performanceDbApi from '../services/performanceDbApi.js'
+import { MiddlewareError } from '../utils/errors.js'
+import { isFeatureEnabled } from '../utils/features.js'
+
+/**
+ * Middleware. Updates req with `task`
+ *
+ * @param {*} req request
+ * @param {*} res response
+ * @param {*} next next function
+ */
+export const prepareTask = (req, res, next) => {
+  const { issueType, field } = req.params
+
+  logger.debug('issue lookup keys', { keys: [...req.aggreatedTasks.keys()] })
+  const task = req.aggreatedTasks.get(`${issueType}|${field}`)
+  if (!task) {
+    return next(new MiddlewareError(`No isssue of type '${issueType}' for field ${field}`, 404))
+  }
+
+  const message = performanceDbApi.getTaskMessage({
+    issue_type: task.issueType,
+    num_issues: task.count,
+    rowCount: req.totalRows,
+    field: task.field,
+    format: 'html'
+  })
+  req.locals.task = { ...task, message }
+  next()
+}
+
+const middlewares = [
+  isFeatureEnabled('checkIssueDetailsPage')
+    ? results.getRequestDataMiddleware
+    : (req, res, next) => { return next(new MiddlewareError('Not found', 404)) },
+  results.getRequestDataMiddleware,
+  results.fetchResponseDetails,
+  results.checkForErroredResponse,
+  results.setupTableParams,
+  results.getIssueTypesWithQualityCriteriaLevels,
+  results.extractIssuesFromResults,
+  results.addQualityCriteriaLevelsToIssues,
+  results.aggregateIssues,
+  results.getBlockingTasks, // we get this to ensure 'missing column issues
+  results.getTotalRows,
+  prepareTask,
+  results.setupError
+]
+
+export default class IssueDetailsController extends PageController {
+  middlewareSetup () {
+    super.middlewareSetup()
+    for (const middleware of middlewares) {
+      this.use(middleware)
+    }
+  }
+
+  async locals (req, res, next) {
+    try {
+      Object.assign(req.form.options, req.locals)
+      super.locals(req, res, next)
+    } catch (error) {
+      next(error)
+    }
+  }
+}

--- a/src/controllers/issueDetailsController.js
+++ b/src/controllers/issueDetailsController.js
@@ -22,7 +22,7 @@ const validateParams = validateQueryParams({
  * @param {*} next next function
  */
 export const prepareTask = (req, res, next) => {
-  const { issueType, field } = req.params
+  const { issueType: issueTypeSlug, field } = req.params
 
   const task = req.aggregatedTasks.get(`${issueType}|${field}`)
   if (!task) {
@@ -30,7 +30,7 @@ export const prepareTask = (req, res, next) => {
   }
 
   let message = issueType // fallback
-  if (issueType === 'missing column') {
+  if (issueTypeSlug === 'missing column') {
     message = results.missingColumnTaskMessage(`<span class="column-name">${task.field}</span>`)
   } else {
     try {
@@ -65,11 +65,17 @@ const setPagination = (req, res, next) => {
   next()
 }
 
+async function setDetailsOptions (req, res, next) {
+  req.locals.detailsOptions = { issue: { ...req.params } }
+  next()
+}
+
 const middlewares = [
   isFeatureEnabled('checkIssueDetailsPage')
     ? validateParams
     : (req, res, next) => { return next(new MiddlewareError('Not found', 404)) },
   results.getRequestDataMiddleware,
+  setDetailsOptions,
   results.fetchResponseDetails,
   results.checkForErroredResponse,
   results.setupTableParams,

--- a/src/controllers/issueDetailsController.js
+++ b/src/controllers/issueDetailsController.js
@@ -24,7 +24,7 @@ const validateParams = validateQueryParams({
 export const prepareTask = (req, res, next) => {
   const { issueType, field } = req.params
 
-  const task = req.aggreatedTasks.get(`${issueType}|${field}`)
+  const task = req.aggregatedTasks.get(`${issueType}|${field}`)
   if (!task) {
     return next(new MiddlewareError(`No isssue of type '${issueType}' for field ${field}`, 404))
   }

--- a/src/controllers/issueDetailsController.js
+++ b/src/controllers/issueDetailsController.js
@@ -10,7 +10,7 @@ import { types } from '../utils/logging.js'
 
 const validateParams = validateQueryParams({
   schema: v.object({
-    pageNumber: v.optional(v.pipe(v.string(), v.transform(parseInt), v.minValue(0)), '0')
+    pageNumber: v.optional(v.pipe(v.string(), v.transform(parseInt), v.minValue(1)), '1')
   })
 })
 

--- a/src/controllers/issueDetailsController.js
+++ b/src/controllers/issueDetailsController.js
@@ -24,12 +24,12 @@ const validateParams = validateQueryParams({
 export const prepareTask = (req, res, next) => {
   const { issueType: issueTypeSlug, field } = req.params
 
-  const task = req.aggregatedTasks.get(`${issueType}|${field}`)
+  const task = req.aggregatedTasks.get(`${issueTypeSlug}|${field}`)
   if (!task) {
-    return next(new MiddlewareError(`No isssue of type '${issueType}' for field ${field}`, 404))
+    return next(new MiddlewareError(`No isssue of type '${issueTypeSlug}' for field ${field}`, 404))
   }
 
-  let message = issueType // fallback
+  let message = issueTypeSlug // fallback
   if (issueTypeSlug === 'missing column') {
     message = results.missingColumnTaskMessage(`<span class="column-name">${task.field}</span>`)
   } else {
@@ -46,7 +46,7 @@ export const prepareTask = (req, res, next) => {
     }
   }
 
-  req.locals.issueType = issueType
+  req.locals.issueType = issueTypeSlug
   req.locals.field = field
   req.locals.task = { ...task, message }
   next()

--- a/src/controllers/issueDetailsController.js
+++ b/src/controllers/issueDetailsController.js
@@ -34,7 +34,6 @@ const middlewares = [
   isFeatureEnabled('checkIssueDetailsPage')
     ? results.getRequestDataMiddleware
     : (req, res, next) => { return next(new MiddlewareError('Not found', 404)) },
-  results.getRequestDataMiddleware,
   results.fetchResponseDetails,
   results.checkForErroredResponse,
   results.setupTableParams,

--- a/src/controllers/issueDetailsController.js
+++ b/src/controllers/issueDetailsController.js
@@ -1,4 +1,3 @@
-import logger from '../utils/logger.js'
 import PageController from './pageController.js'
 import * as results from './resultsController.js'
 import performanceDbApi from '../services/performanceDbApi.js'
@@ -15,7 +14,6 @@ import { isFeatureEnabled } from '../utils/features.js'
 export const prepareTask = (req, res, next) => {
   const { issueType, field } = req.params
 
-  logger.debug('issue lookup keys', { keys: [...req.aggreatedTasks.keys()] })
   const task = req.aggreatedTasks.get(`${issueType}|${field}`)
   if (!task) {
     return next(new MiddlewareError(`No isssue of type '${issueType}' for field ${field}`, 404))

--- a/src/controllers/resultsController.js
+++ b/src/controllers/resultsController.js
@@ -88,14 +88,21 @@ export function setupTemplate (req, res, next) {
   }
 }
 
+/**
+ * @param {import('express').Request & { locals: { detailsOptions?: { severity?: string, issue?: { issueType: string, field: string }}}}} req request
+ * @param {*} res
+ * @param {*} next
+ * @returns
+ */
 export async function fetchResponseDetails (req, res, next) {
   const { pageNumber } = req.parsedParams
   try {
     if (req.locals.template !== failedFileRequestTemplate && req.locals.template !== failedUrlRequestTemplate) {
+      const detailsOpts = req.locals.detailsOptions ?? {}
       const responseDetails = req.locals.template === resultsTemplate
         // pageNumber starts with: 1, fetchResponseDetails parameter `pageOffset` starts with 0
-        ? await req.locals.requestData.fetchResponseDetails(pageNumber - 1, 50, 'error')
-        : await req.locals.requestData.fetchResponseDetails(pageNumber - 1)
+        ? await req.locals.requestData.fetchResponseDetails(pageNumber - 1, 50, { severity: 'error', ...detailsOpts })
+        : await req.locals.requestData.fetchResponseDetails(pageNumber - 1, 50, { ...detailsOpts })
       req.locals.responseDetails = responseDetails
     }
   } catch (e) {

--- a/src/controllers/resultsController.js
+++ b/src/controllers/resultsController.js
@@ -302,6 +302,10 @@ export function getTasksByLevel (req, level, status) {
   req.locals[`tasks${level === 2 ? 'Blocking' : 'NonBlocking'}`] = taskParams
 }
 
+export const missingColumnTaskMessage = (field) => {
+  return `${field} column is missing`
+}
+
 export function getMissingColumnTasks (req) {
   const { responseDetails } = req.locals
   const taskMap = new Map()
@@ -315,7 +319,7 @@ export function getMissingColumnTasks (req) {
         count: 1
       })
       tasks.push(makeTaskParam(req, {
-        taskMessage: `${column.field} column is missing`,
+        taskMessage: missingColumnTaskMessage(column.field),
         status: taskStatus.mustFix,
         field: column.field,
         issueType: 'missing column'

--- a/src/controllers/resultsController.js
+++ b/src/controllers/resultsController.js
@@ -224,7 +224,7 @@ export function aggregateIssues (req, res, next) {
     }
   }
 
-  req.aggreatedTasks = taskMap
+  req.aggregatedTasks = taskMap
   req.tasks = Array.from(taskMap.values())
 
   next()
@@ -330,7 +330,7 @@ export function getMissingColumnTasks (req) {
  * Middleware. Updates `req.locals` with `tasksBlocking` and potentially updates
  * `req.aggregatedTasks` map with entrires for missing columns.
  *
- * @param {import('express').Request & { aggreatedTasks: Map<string, Object>}} req request
+ * @param {import('express').Request & { aggregatedTasks: Map<string, Object>}} req request
  * @param {*} res response
  * @param {*} next next function
  */
@@ -341,7 +341,7 @@ export function getBlockingTasks (req, res, next) {
   const { tasks: missingColumnTasks, taskMap } = getMissingColumnTasks(req)
   req.locals.tasksBlocking = req.locals.tasksBlocking.concat(missingColumnTasks)
   for (const [k, v] of taskMap.entries()) {
-    req.aggreatedTasks.set(k, v)
+    req.aggregatedTasks.set(k, v)
   }
   next()
 }

--- a/src/models/requestData.js
+++ b/src/models/requestData.js
@@ -13,9 +13,15 @@ export default class ResultData {
     Object.assign(this, responseData)
   }
 
-  async fetchResponseDetails (pageNumber = 0, limit = 50, severity = undefined) {
+  /**
+   * @param {number} pageOffset zero based
+   * @param {number} limit limit
+   * @param {string?} severity severity
+   * @returns {ResponseDetails}
+   */
+  async fetchResponseDetails (pageOffset = 0, limit = 50, severity = undefined) {
     const urlParams = new URLSearchParams()
-    urlParams.append('offset', pageNumber * limit)
+    urlParams.append('offset', pageOffset * limit)
     urlParams.append('limit', limit)
     if (severity) {
       urlParams.append('jsonpath', `$.issue_logs[*].severity=="${severity}"`)

--- a/src/models/responseDetails.js
+++ b/src/models/responseDetails.js
@@ -152,7 +152,7 @@ export default class ResponseDetails {
 
   /**
    * @param {number} pageNumber
-   * @param {{ hash?: string }} opts hash option should include the '#' character
+   * @param {{ hash?: string, href?: (item: number) => string }} opts hash option should include the '#' character
    * @returns {{ totalResults: number, offset: number, limit: number, currentPage: number, nextPage: number | null, previousPage: number | null, totalPages: number, items: { href: string }[] } }
    */
   getPagination (pageNumber, opts = {}) {
@@ -161,6 +161,7 @@ export default class ResponseDetails {
     const totalPages = Math.ceil(this.pagination.totalResults / this.pagination.limit)
 
     const hash = opts.hash ?? ''
+    const hrefFn = opts.href ?? ((item) => `/check/results/${this.id}/${item}${hash}`)
     const items = pagination(totalPages, pageNumber + 1).map(item => {
       if (item === '...') {
         return {
@@ -170,8 +171,8 @@ export default class ResponseDetails {
       } else {
         return {
           number: item,
-          href: `/check/results/${this.id}/${parseInt(item) - 1}${hash}`,
-          current: pageNumber === parseInt(item) - 1
+          href: hrefFn(item - 1),
+          current: pageNumber === item - 1
         }
       }
     })

--- a/src/models/responseDetails.js
+++ b/src/models/responseDetails.js
@@ -46,11 +46,16 @@ export default class ResponseDetails {
     return [...new Set(ColumnsWithDuplicates)]
   }
 
+  /**
+   * returned fields are `converted_row.column | columnFieldLog.field`
+   *
+   * @returns {string[]}
+   */
   getFields () {
     const columnKeys = [...new Set(this.getRows().map(row => row.converted_row).flatMap(row => Object.keys(row)))]
 
+    const columnFieldLog = this.getColumnFieldLog()
     return [...new Set(columnKeys.map(column => {
-      const columnFieldLog = this.getColumnFieldLog()
       const fieldLog = columnFieldLog.find(fieldLog => fieldLog.column === column)
       if (!fieldLog) {
         return column

--- a/src/models/responseDetails.js
+++ b/src/models/responseDetails.js
@@ -152,7 +152,7 @@ export default class ResponseDetails {
 
   /**
    * @param {number} pageNumber
-   * @param {{ hash?: string }} options hash option should include the '#' character
+   * @param {{ hash?: string }} opts hash option should include the '#' character
    * @returns {{ totalResults: number, offset: number, limit: number, currentPage: number, nextPage: number | null, previousPage: number | null, totalPages: number, items: { href: string }[] } }
    */
   getPagination (pageNumber, opts = {}) {

--- a/src/models/responseDetails.js
+++ b/src/models/responseDetails.js
@@ -157,12 +157,12 @@ export default class ResponseDetails {
    */
   getPagination (pageNumber, opts = {}) {
     pageNumber = parseInt(pageNumber)
-    if (Number.isNaN(pageNumber)) pageNumber = 0
+    if (Number.isNaN(pageNumber)) pageNumber = 1
     const totalPages = Math.ceil(this.pagination.totalResults / this.pagination.limit)
 
     const hash = opts.hash ?? ''
     const hrefFn = opts.href ?? ((item) => `/check/results/${this.id}/${item}${hash}`)
-    const items = pagination(totalPages, pageNumber + 1).map(item => {
+    const items = pagination(totalPages, pageNumber).map(item => {
       if (item === '...') {
         return {
           ellipsis: true,
@@ -171,8 +171,8 @@ export default class ResponseDetails {
       } else {
         return {
           number: item,
-          href: hrefFn(item - 1),
-          current: pageNumber === item - 1
+          href: hrefFn(item),
+          current: pageNumber === item
         }
       }
     })
@@ -181,9 +181,9 @@ export default class ResponseDetails {
       totalResults: parseInt(this.pagination.totalResults),
       offset: parseInt(this.pagination.offset),
       limit: parseInt(this.pagination.limit),
-      currentPage: pageNumber + 1,
-      nextPage: pageNumber < totalPages - 1 ? pageNumber + 1 : null,
-      previousPage: pageNumber > 0 ? pageNumber - 1 : null,
+      currentPage: pageNumber,
+      nextPage: pageNumber < totalPages ? pageNumber + 1 : null,
+      previousPage: pageNumber > 1 ? pageNumber - 1 : null,
       totalPages,
       items
     }

--- a/src/routes/form-wizard/check/steps.js
+++ b/src/routes/form-wizard/check/steps.js
@@ -75,7 +75,7 @@ export default {
     controller: statusController,
     checkJourney: false,
     entryPoint: true,
-    next: (req, res) => `results/${req.params.id}/0`
+    next: (req, res) => `results/${req.params.id}/1`
   },
   '/results/:id/:pageNumber': {
     ...baseSettings,

--- a/src/routes/form-wizard/check/steps.js
+++ b/src/routes/form-wizard/check/steps.js
@@ -86,7 +86,7 @@ export default {
     forwardQuery: true,
     next: 'confirmation'
   },
-  '/results/:id/issue/:issueType/:field': {
+  '/results/:id/issue/:issueType/:field/:pageNumber?': {
     ...baseSettings,
     controller: issueDetailsController,
     noPost: true,

--- a/src/routes/form-wizard/check/steps.js
+++ b/src/routes/form-wizard/check/steps.js
@@ -9,6 +9,7 @@ import submitUrlController from '../../../controllers/submitUrlController.js'
 import statusController from '../../../controllers/statusController.js'
 import resultsController from '../../../controllers/resultsController.js'
 import checkDeepLinkController from '../../../controllers/checkDeepLinkController.js'
+import issueDetailsController from '../../../controllers/issueDetailsController.js'
 
 const baseSettings = {
   controller: PageController,
@@ -84,6 +85,15 @@ export default {
     entryPoint: true,
     forwardQuery: true,
     next: 'confirmation'
+  },
+  '/results/:id/issue/:issueType/:field': {
+    ...baseSettings,
+    controller: issueDetailsController,
+    noPost: true,
+    checkJourney: false,
+    entryPoint: true,
+    forwardQuery: true,
+    template: 'check/results/issueDetails.html'
   },
   '/confirmation': {
     ...baseSettings,

--- a/src/serverSetup/routes.js
+++ b/src/serverSetup/routes.js
@@ -9,21 +9,6 @@ import privacy from '../routes/privacy.js'
 import cookies from '../routes/cookies.js'
 import guidance from '../routes/guidance.js'
 import { isFeatureEnabled } from '../utils/features.js'
-import { renderTemplate } from '../middleware/middleware.builders.js'
-
-const renderWhatever = renderTemplate({
-  templateParams: (req) => {
-    return {
-      organisation: { name: 'Lincolshire' },
-      dataset: { name: 'Tree Outline or whatever' },
-      task: {
-        qualityCriteriaLevel: 2
-      }
-    }
-  },
-  template: 'check/results/issueDetails.html',
-  handlerName: 'whatever'
-})
 
 export function setupRoutes (app) {
   app.use('/', manage)
@@ -37,7 +22,6 @@ export function setupRoutes (app) {
   app.use('/privacy-notice', privacy)
   app.use('/cookies', cookies)
   app.use('/health', health)
-  app.use('/whatever', renderWhatever)
 
   // feature flagged routes
   if (isFeatureEnabled('submitEndpointForm')) app.use('/submit', endpointSubmissionFormFormWisard)

--- a/src/serverSetup/routes.js
+++ b/src/serverSetup/routes.js
@@ -9,6 +9,21 @@ import privacy from '../routes/privacy.js'
 import cookies from '../routes/cookies.js'
 import guidance from '../routes/guidance.js'
 import { isFeatureEnabled } from '../utils/features.js'
+import { renderTemplate } from '../middleware/middleware.builders.js'
+
+const renderWhatever = renderTemplate({
+  templateParams: (req) => {
+    return {
+      organisation: { name: 'Lincolshire' },
+      dataset: { name: 'Tree Outline or whatever' },
+      task: {
+        qualityCriteriaLevel: 2
+      }
+    }
+  },
+  template: 'check/results/issueDetails.html',
+  handlerName: 'whatever'
+})
 
 export function setupRoutes (app) {
   app.use('/', manage)
@@ -22,6 +37,7 @@ export function setupRoutes (app) {
   app.use('/privacy-notice', privacy)
   app.use('/cookies', cookies)
   app.use('/health', health)
+  app.use('/whatever', renderWhatever)
 
   // feature flagged routes
   if (isFeatureEnabled('submitEndpointForm')) app.use('/submit', endpointSubmissionFormFormWisard)

--- a/src/services/asyncRequestApi.js
+++ b/src/services/asyncRequestApi.js
@@ -54,10 +54,10 @@ const postRequest = async (formData) => {
   }
 }
 
-export const getRequestData = async (resultId) => {
+export const getRequestData = async (resultId, opts = undefined) => {
+  const url = new URL(`${config.asyncRequestApi.url}/${config.asyncRequestApi.requestsEndpoint}/${resultId}`)
   try {
-    const response = await axios.get(`${config.asyncRequestApi.url}/${config.asyncRequestApi.requestsEndpoint}/${resultId}`)
-
+    const response = await axios.get(url)
     return new ResultData(response.data)
   } catch (error) {
     throw new Error(`HTTP error! status: ${error.status}: ${error.message}`, { cause: error })

--- a/src/services/performanceDbApi.js
+++ b/src/services/performanceDbApi.js
@@ -10,38 +10,68 @@ import { types } from '../utils/logging.js'
 // for now we are using a csv for these messages but we will probably end up moving to a table, so for now this can sit in the fake performance db api
 
 import csv from 'csv-parser' // ToDo: remember to remove this from package.json when we move away from csv
-import fs from 'fs'
+import fs from 'node:fs'
 
 const messages = new Map()
 
-fs.createReadStream('src/content/fieldIssueMessages.csv').pipe(csv()).on('data', row => {
-  messages.set(row.issue_type, {
-    singular: row.singular_message,
-    plural: row.plural_message
+/**
+ * Reads messages from CSV files and populates `messages` map.
+ */
+export async function initialiseMessages () {
+  // the csv parser works streams so we have wrap it with promises
+  const fieldIssuesMessages = new Promise((resolve, reject) => {
+    fs.createReadStream('src/content/fieldIssueMessages.csv').pipe(csv()).on('data', row => {
+      try {
+        messages.set(row.issue_type, {
+          singular: row.singular_message,
+          plural: row.plural_message
+        })
+      } catch (error) {
+        reject(error)
+      }
+    }).on('end', () => {
+      logger.debug('finished populating messages', { type: types.App })
+      resolve(messages)
+    })
   })
-}).on('end', () => {
-  getEntityMessages()
-  getAllRowsMessages()
-})
 
-function getEntityMessages () {
-  fs.createReadStream('src/content/entityIssueMessages.csv').pipe(csv()).on('data', row => {
-    const messageInfo = messages.get(row.issue_type)
-    messageInfo.entities_singular = row.singular_message
-    messageInfo.entities_plural = row.plural_message
-  }).on('end', () => {
-    // Messages object is now populated
+  await fieldIssuesMessages
+
+  const entityMessages = new Promise((resolve, reject) => {
+    fs.createReadStream('src/content/entityIssueMessages.csv').pipe(csv()).on('data', row => {
+      try {
+        const messageInfo = messages.get(row.issue_type)
+        messageInfo.entities_singular = row.singular_message
+        messageInfo.entities_plural = row.plural_message
+      } catch (error) {
+        reject(error)
+      }
+    }).on('end', () => {
+      resolve(messages)
+    })
   })
+
+  await entityMessages
+
+  const allRowsMessages = new Promise((resolve, reject) => {
+    fs.createReadStream('src/content/allRowsIssueMessages.csv').pipe(csv()).on('data', row => {
+      try {
+        const messageInfo = messages.get(row.issue_type)
+        messageInfo.allRows_message = row.allRows_message
+      } catch (error) {
+        reject(error)
+      }
+    }).on('end', () => {
+      // Messages object is now populated
+      logger.info('allRowsMessages stream end', { type: types.App })
+      resolve(messages)
+    })
+  })
+
+  await allRowsMessages
 }
 
-function getAllRowsMessages () {
-  fs.createReadStream('src/content/allRowsIssueMessages.csv').pipe(csv()).on('data', row => {
-    const messageInfo = messages.get(row.issue_type)
-    messageInfo.allRows_message = row.allRows_message
-  }).on('end', () => {
-    // Messages object is now populated
-  })
-}
+await initialiseMessages()
 
 // ===========================================
 

--- a/src/services/performanceDbApi.js
+++ b/src/services/performanceDbApi.js
@@ -188,7 +188,10 @@ export default {
   /**
      * Returns a task message based on the provided issue type, issue count, and entity count.
      *
-     * @param {{issue_type: string, num_issues: number, rowCount: number, field: string }} options
+     * Pass format = 'html' if you want the fields in the message to be marked up with span.column-name. Otherwise
+     * plain text message is returned.
+     *
+     * @param {{issue_type: string, num_issues: number, rowCount: number, field: string, format?: 'html' }} options
      * @param {boolean?} entityLevel Whether to use entity-level or dataset level messaging
      *
      * @returns {string} The task message with the issue count inserted
@@ -199,7 +202,8 @@ export default {
     issue_type: issueType,
     num_issues: numIssues,
     rowCount,
-    field
+    field,
+    ...rest
   }, entityLevel = false) {
     const messageInfo = messages.get(issueType)
     if (!messageInfo) {
@@ -227,7 +231,8 @@ export default {
         ? messageInfo.singular
         : messageInfo.plural
     }
-    return message.replace('{num_issues}', numIssues).replace('{num_entries}', numIssues).replace('{column_name}', field)
+    const fieldText = rest.format === 'html' ? `<span class="column-name">${field}</span>` : field
+    return message.replace('{num_issues}', numIssues).replace('{num_entries}', numIssues).replace('{column_name}', fieldText)
   },
 
   latestResourceQuery: (lpa, dataset) => {

--- a/src/views/check/results/issueDetails.html
+++ b/src/views/check/results/issueDetails.html
@@ -15,7 +15,7 @@
   {% if options.lastPage %}
     {{ govukBackLink({
       text: options.backLinkText | default("Back"),
-      href: '/check/results/' + (options.id | urlencode) + '/0'
+      href: '/check/results/' + (options.id | urlencode) + '/1'
     }) }}
   {% endif %}
 
@@ -90,7 +90,7 @@
   <div class="govuk-grid-column-two-thirds">
     {{ govukBackLink({
       text: "Back to results",
-      href: '/check/results/' +  (options.id | urlencode) + '/0'
+      href: '/check/results/' +  (options.id | urlencode) + '/1'
     }) }}
   </div>
 </div>

--- a/src/views/check/results/issueDetails.html
+++ b/src/views/check/results/issueDetails.html
@@ -1,0 +1,98 @@
+{% extends "layouts/main.html" %}
+
+{% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/pagination/macro.njk" import govukPagination %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "../../components/table.html" import table %}
+
+{% set serviceType = 'Submit'%}
+
+{% set pageName = ('Issue details for ' + options.deepLink.datasetName) if options.deepLink.datasetName else 'Issue details' %}
+
+{% block beforeContent %}
+
+  {% if options.lastPage %}
+    {{ govukBackLink({
+      text: options.backLinkText | default("Back"),
+      href: '/check/results/' + (options.id | urlencode) + '/0'
+    }) }}
+  {% endif %}
+
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  {% include "includes/_dataset-issue-page-header.html" %}
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    {% set criteriaLabels = { '2': 'You cannot submit your data until you fix the issues', '3': 'You can submit your data and fix these issues later' } %}
+    {{ govukErrorSummary({
+      titleText: criteriaLabels[options.task.qualityCriteriaLevel] or 'There is a problem',
+      errorList: [ { html: options.task.message, href: ""}]
+    }) }}
+
+    {% if entry.fields.length  %}
+      {{ govukSummaryList({
+        card: {
+          title: {
+            text: entry.title
+          }
+        },
+        rows: entry.fields
+      }) }}
+    {% endif %}
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    {% if options.tableParams.rows|length > 0 %}
+        {{ table(options.tableParams) }}
+    {% endif %}
+
+    {% if options.pagination.items | length > 1 %}
+        {{ govukPagination({
+        previous: {
+            href: '/check/results/'+options.id+'/'+options.pagination.previousPage + '#table-tab'
+        } if options.pagination.previousPage else undefined,
+        next: {
+            href: '/check/results/'+options.id+'/'+options.pagination.nextPage + '#table-tab'
+        } if options.pagination.nextPage else undefined,
+        items: options.pagination.items
+        })}}
+    {% endif %}
+
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h3 class="govuk-heading-m">
+      How to improve {{ options.deepLink.orgName | default('your organisation') }}’s data
+    </h3>
+
+    <ol class="govuk-list govuk-list--number">
+      <li>Fix the errors indicated</li>
+      <li>Use the <a href="/check">check service</a> to make sure the data meets
+        the standard</li>
+      <li>Publish the updated data on the data URL</li>
+    </ol>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    {{ govukBackLink({
+      text: "Back to results",
+      href: '/check/results/' +  (options.id | urlencode) + '/0'
+    }) }}
+  </div>
+</div>
+
+{% endblock %}

--- a/src/views/check/results/issueDetails.html
+++ b/src/views/check/results/issueDetails.html
@@ -79,8 +79,8 @@
 
     <ol class="govuk-list govuk-list--number">
       <li>Fix the errors indicated</li>
-      <li>Use the <a href="/check">check service</a> to make sure the data meets
-        the standard</li>
+      <li>Use the <a href="{{ { name: options.lpa, organisation: options.orgId } | checkToolDeepLink({ dataset: options.dataset }) }}">check service</a> to make sure the data meets
+        the standard: {{ options.orgId }}</li>
       <li>Publish the updated data on the data URL</li>
     </ol>
   </div>

--- a/src/views/check/results/issueDetails.html
+++ b/src/views/check/results/issueDetails.html
@@ -59,10 +59,10 @@
     {% if options.pagination.items | length > 1 %}
         {{ govukPagination({
         previous: {
-            href: '/check/results/'+options.id+'/'+options.pagination.previousPage + '#table-tab'
+            href: '/check/results/'+options.id+'/issue/'+ options.issueType + '/' + options.field + '/' + options.pagination.previousPage
         } if options.pagination.previousPage else undefined,
         next: {
-            href: '/check/results/'+options.id+'/'+options.pagination.nextPage + '#table-tab'
+             href: '/check/results/'+options.id+'/issue/'+ options.issueType + '/' + options.field + '/' + options.pagination.nextPage
         } if options.pagination.nextPage else undefined,
         items: options.pagination.items
         })}}

--- a/src/views/includes/_dataset-issue-page-header.html
+++ b/src/views/includes/_dataset-issue-page-header.html
@@ -1,0 +1,8 @@
+<div class="govuk-grid-column-two-thirds">
+  {% if options.deepLink.orgName and options.deepLink.datasetName %}
+      <span class="govuk-caption-l">{{ options.deepLink.orgName }} — {{ options.deepLink.datasetName }}</span>
+  {% elif organisation.name and dataset.name %}
+    <span class="govuk-caption-l">{{ organisation.name }} — {{ dataset.name }}</span>
+  {% endif %}
+  <h1 class="govuk-heading-l">Your data has issues</h1>
+</div>

--- a/src/views/includes/_dataset-issue-page-header.html
+++ b/src/views/includes/_dataset-issue-page-header.html
@@ -1,10 +1,8 @@
+{% from '../components/dataset-banner.html' import datasetBanner %}
+
 <div class="govuk-grid-column-two-thirds">
-  {% if options.deepLink.orgName and options.deepLink.datasetName %}
-      <span class="govuk-caption-l">{{ options.deepLink.orgName }} — {{ options.deepLink.datasetName }}</span>
-  {% elif organisation.name and dataset.name %}
-    <span class="govuk-caption-l">{{ organisation.name }} — {{ dataset.name }}</span>
-  {% elif options.datasetName %}
-    <span class="govuk-caption-l">{{ options.datasetName }}</span>
-  {% endif %}
+  {{ datasetBanner(options.lpa, options.datasetName or options.requestParams.dataset) }}
+
   <h1 class="govuk-heading-l">Your data has issues</h1>
+
 </div>

--- a/src/views/includes/_dataset-issue-page-header.html
+++ b/src/views/includes/_dataset-issue-page-header.html
@@ -3,6 +3,8 @@
       <span class="govuk-caption-l">{{ options.deepLink.orgName }} — {{ options.deepLink.datasetName }}</span>
   {% elif organisation.name and dataset.name %}
     <span class="govuk-caption-l">{{ organisation.name }} — {{ dataset.name }}</span>
+  {% elif options.datasetName %}
+    <span class="govuk-caption-l">{{ options.datasetName }}</span>
   {% endif %}
   <h1 class="govuk-heading-l">Your data has issues</h1>
 </div>

--- a/src/views/organisations/issueDetails.html
+++ b/src/views/organisations/issueDetails.html
@@ -102,7 +102,7 @@
 
     <ol class="govuk-list govuk-list--number">
       <li>Fix the errors indicated</li>
-      <li>Use the <a href="/check">check service</a> to make sure the data meets
+      <li>Use the <a href="{{ organisation | checkToolDeepLink(dataset) }}">check service</a> to make sure the data meets
         the standard</li>
       <li>Publish the updated data on the data URL</li>
     </ol>

--- a/src/views/organisations/issueTable.html
+++ b/src/views/organisations/issueTable.html
@@ -58,7 +58,7 @@
 </div>
 
 <div class="govuk-grid-row">
-  {% include "includes/_dataset-page-header.html" %}
+  {% include "includes/_dataset-issue-page-header.html" %}
 </div>
 
 <div class="govuk-grid-row">

--- a/src/views/organisations/issueTable.html
+++ b/src/views/organisations/issueTable.html
@@ -135,7 +135,7 @@
 
     <ol class="govuk-list govuk-list--number">
       <li>Fix the errors indicated</li>
-      <li>Use the <a href="/check">check service</a> to make sure the data meets
+      <li>Use the <a href="{{ organisation | checkToolDeepLink(dataset) }}">check service</a> to make sure the data meets
         the standard</li>
       <li>Publish the updated data on the data URL</li>
     </ol>

--- a/test/PageObjectModels/resultsPage.js
+++ b/test/PageObjectModels/resultsPage.js
@@ -19,15 +19,15 @@ export default class ResultsPage extends BasePage {
     expect(['There was a problem with the url provided', "The file you provided wasn't readable"]).toContain(await this.page.locator('h1').innerText())
   }
 
-  async navigateToRequest (id, pageNumber = 0) {
+  async navigateToRequest (id, pageNumber = 1) {
     return await this.page.goto(`${this.url}/${id}/${pageNumber}`)
   }
 
   async waitForPage (id = undefined) {
     if (id) {
-      return await this.page.waitForURL(`**${this.url}/${id}/0`)
+      return await this.page.waitForURL(`**${this.url}/${id}/1`)
     } else {
-      return await this.page.waitForURL(`**${this.url}/**/0`)
+      return await this.page.waitForURL(`**${this.url}/**/1`)
     }
   }
 

--- a/test/acceptance/request_check.test.js
+++ b/test/acceptance/request_check.test.js
@@ -6,7 +6,7 @@
         - request check of a datafile when javascript fails
 */
 
-import { test } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 import UploadMethodPage, { uploadMethods } from '../PageObjectModels/uploadMethodPage'
 
 test.setTimeout(300000)
@@ -20,6 +20,105 @@ const okFile = 'https://raw.githubusercontent.com/digital-land/PublishExamples/r
 const errorFile = 'https://raw.githubusercontent.com/digital-land/PublishExamples/refs/heads/main/Article4Direction/Files/Article4DirectionArea/article4directionareas-errors.csv'
 
 let lastTimestamp = 0
+
+async function checkDataFile ({ page, jsEnabled }) {
+  log(`Starting test: request check of a @datafile, jsEnabled=${jsEnabled}`, true)
+
+  const uploadMethodPage = await navigateToCheck(page)
+  await uploadMethodPage.waitForPage()
+  await uploadMethodPage.selectUploadMethod(uploadMethods.File)
+  const uploadFilePage = await uploadMethodPage.clickContinue()
+
+  await uploadFilePage.waitForPage()
+  await uploadFilePage.uploadFile('test/datafiles/article4directionareas-ok.csv')
+  const statusPage = await uploadFilePage.clickContinue()
+
+  await statusPage.waitForPage()
+  await statusPage.expectPageToBeProcessing()
+
+  if (jsEnabled) {
+    await statusPage.expectPageToHaveFinishedProcessing()
+  } else {
+    await statusPage.expectCheckStatusButtonToBeVisible()
+    await page.waitForTimeout(5000)
+  }
+
+  const id = await statusPage.getIdFromUrl()
+  log(`Extracted ID from URL: ${id}`)
+
+  /** @type {import('../PageObjectModels/resultsPage.js').default} ResultsPage */
+  let resultsPage
+  if (jsEnabled) {
+    resultsPage = await statusPage.clickContinue()
+    resultsPage.expectPageHasTabs(false)
+  } else {
+    await page.waitForTimeout(5000)
+    resultsPage = await statusPage.clickCheckStatusButton()
+  }
+
+  await resultsPage.waitForPage(id)
+  await resultsPage.expectPageHasTitle()
+  await resultsPage.expectPageHasTabs(jsEnabled)
+  const confirmationPage = await resultsPage.clickContinue()
+  log('Navigated to confirmation page')
+  await confirmationPage.waitForPage()
+  log('Confirmation page loaded')
+}
+
+async function checkErrorDataFile ({ page, jsEnabled }) {
+  log(`Starting test: request check of an error @datafile, jsEnabled=${jsEnabled}`, true)
+
+  const uploadMethodPage = await navigateToCheck(page)
+  await uploadMethodPage.waitForPage()
+  await uploadMethodPage.selectUploadMethod(uploadMethods.File)
+  /** @type {import('../PageObjectModels/uploadFilePage').default} UploadFilePage */
+  const uploadFilePage = await uploadMethodPage.clickContinue()
+
+  await uploadFilePage.waitForPage()
+  await uploadFilePage.uploadFile('test/datafiles/article4directionareas-error.csv')
+  /** @type {import('../PageObjectModels/statusPage.js').default} StatusPage */
+  const statusPage = await uploadFilePage.clickContinue()
+
+  await statusPage.waitForPage()
+  await statusPage.expectPageToBeProcessing()
+
+  if (jsEnabled) {
+    await statusPage.expectPageToHaveFinishedProcessing()
+  } else {
+    await statusPage.expectCheckStatusButtonToBeVisible()
+  }
+
+  const id = await statusPage.getIdFromUrl()
+  log(`Extracted ID from URL: ${id}`)
+  /** @type {import('../PageObjectModels/resultsPage.js').default} ResultsPage */
+  let resultsPage
+  if (jsEnabled) {
+    resultsPage = await statusPage.clickContinue()
+  } else {
+    await page.waitForTimeout(5000)
+    resultsPage = await statusPage.clickCheckStatusButton()
+  }
+
+  await resultsPage.waitForPage(id)
+  await resultsPage.expectPageHasTitle()
+  await resultsPage.expectPageHasBlockingTasks()
+  await resultsPage.expectPageHasTabs(jsEnabled)
+
+  // issue details page
+  await page.getByText('description column is missing').click()
+  await page.waitForURL(/\/check\/results\/.*\/issue\/.*/, { timeout: 4000 })
+  await expect(page.getByText('Your data has issues')).toBeVisible()
+  await expect(page.getByText('You cannot submit your data until you fix the issues')).toBeVisible()
+  const itemsLocator = page.locator('.govuk-error-summary ul li')
+  expect(await itemsLocator.count()).toBe(1)
+  await expect(itemsLocator).toContainText('1 issue of type missing column')
+  await expect(page.getByText('How to improve Adur District Council’s data')).toBeVisible()
+
+  // verify we get correctly routed to a 404
+  const nonExistingIssue = page.url().replace(/.*\/check/, '/check').replace('/description', '/foobar')
+  const response = await page.goto(nonExistingIssue)
+  expect(response.status()).toBe(404)
+}
 
 function log (message, start = false) {
   if (start) {
@@ -36,56 +135,11 @@ function log (message, start = false) {
 test.describe('Request Check', () => {
   test.describe('with javascript enabled', () => {
     test('request check of a @datafile', async ({ page }) => {
-      log('Starting test: request check of a @datafile', true)
-
-      const uploadMethodPage = await navigateToCheck(page)
-      await uploadMethodPage.waitForPage()
-      await uploadMethodPage.selectUploadMethod(uploadMethods.File)
-      const uploadFilePage = await uploadMethodPage.clickContinue()
-
-      await uploadFilePage.waitForPage()
-      await uploadFilePage.uploadFile('test/datafiles/article4directionareas-ok.csv')
-      const statusPage = await uploadFilePage.clickContinue()
-
-      await statusPage.waitForPage()
-      await statusPage.expectPageToBeProcessing()
-      await statusPage.expectPageToHaveFinishedProcessing()
-      const id = await statusPage.getIdFromUrl()
-      log(`Extracted ID from URL: ${id}`)
-      const resultsPage = await statusPage.clickContinue()
-
-      await resultsPage.waitForPage(id)
-      await resultsPage.expectPageHasTitle()
-      await resultsPage.expectPageHasTabs()
-      const confirmationPage = await resultsPage.clickContinue()
-      log('Navigated to confirmation page')
-      await confirmationPage.waitForPage()
-      log('Confirmation page loaded')
+      await checkDataFile({ page, jsEnabled: true })
     })
 
     test('request check of an error @datafile', async ({ page }) => {
-      log('Starting test: request check of an error @datafile', true)
-
-      const uploadMethodPage = await navigateToCheck(page)
-      await uploadMethodPage.waitForPage()
-      await uploadMethodPage.selectUploadMethod(uploadMethods.File)
-      const uploadFilePage = await uploadMethodPage.clickContinue()
-
-      await uploadFilePage.waitForPage()
-      await uploadFilePage.uploadFile('test/datafiles/article4directionareas-error.csv')
-      const statusPage = await uploadFilePage.clickContinue()
-
-      await statusPage.waitForPage()
-      await statusPage.expectPageToBeProcessing()
-      await statusPage.expectPageToHaveFinishedProcessing()
-      const id = await statusPage.getIdFromUrl()
-      log(`Extracted ID from URL: ${id}`)
-      const resultsPage = await statusPage.clickContinue()
-
-      await resultsPage.waitForPage(id)
-      await resultsPage.expectPageHasTitle()
-      await resultsPage.expectPageHasBlockingTasks()
-      await resultsPage.expectPageHasTabs()
+      await checkErrorDataFile({ page, jsEnabled: true })
     })
 
     test('request check of a @url', async ({ page }) => {
@@ -146,59 +200,11 @@ test.describe('Request Check', () => {
     test.use({ javaScriptEnabled: false })
 
     test('request check of a @datafile', async ({ page }) => {
-      log('Starting test: request check of a @datafile with javascript disabled', true)
-
-      const uploadMethodPage = await navigateToCheck(page)
-      await uploadMethodPage.waitForPage()
-      await uploadMethodPage.selectUploadMethod(uploadMethods.File)
-      const uploadFilePage = await uploadMethodPage.clickContinue()
-
-      await uploadFilePage.waitForPage()
-      await uploadFilePage.uploadFile('test/datafiles/article4directionareas-ok.csv')
-      const statusPage = await uploadFilePage.clickContinue()
-
-      await statusPage.waitForPage()
-      await statusPage.expectPageToBeProcessing()
-      await statusPage.expectCheckStatusButtonToBeVisible()
-      const id = await statusPage.getIdFromUrl()
-      log(`Extracted ID from URL: ${id}`)
-
-      await page.waitForTimeout(5000)
-      const resultsPage = await statusPage.clickCheckStatusButton()
-
-      await resultsPage.waitForPage(id)
-      await resultsPage.expectPageHasTitle()
-      await resultsPage.expectPageHasTabs(false)
-      const confirmationPage = await resultsPage.clickContinue()
-      await confirmationPage.waitForPage()
-      log('Navigated to confirmation page')
+      await checkDataFile({ page, jsEnabled: false })
     })
 
     test('request check of an error @datafile', async ({ page }) => {
-      log('Starting test: request check of an error @datafile with javascript disabled', true)
-
-      const uploadMethodPage = await navigateToCheck(page)
-      await uploadMethodPage.waitForPage()
-      await uploadMethodPage.selectUploadMethod(uploadMethods.File)
-      const uploadFilePage = await uploadMethodPage.clickContinue()
-
-      await uploadFilePage.waitForPage()
-      await uploadFilePage.uploadFile('test/datafiles/article4directionareas-error.csv')
-      const statusPage = await uploadFilePage.clickContinue()
-
-      await statusPage.waitForPage()
-      await statusPage.expectPageToBeProcessing()
-      await statusPage.expectCheckStatusButtonToBeVisible()
-      const id = await statusPage.getIdFromUrl()
-      log(`Extracted ID from URL: ${id}`)
-
-      await page.waitForTimeout(5000)
-      const resultsPage = await statusPage.clickCheckStatusButton()
-
-      await resultsPage.waitForPage(id)
-      await resultsPage.expectPageHasTitle()
-      await resultsPage.expectPageHasBlockingTasks()
-      await resultsPage.expectPageHasTabs(false)
+      await checkErrorDataFile({ page, jsEnabled: false })
     })
 
     test('request check of a @url', async ({ page }) => {

--- a/test/acceptance/request_check.test.js
+++ b/test/acceptance/request_check.test.js
@@ -111,7 +111,7 @@ async function checkErrorDataFile ({ page, jsEnabled }) {
   await expect(page.getByText('You cannot submit your data until you fix the issues')).toBeVisible()
   const itemsLocator = page.locator('.govuk-error-summary ul li')
   expect(await itemsLocator.count()).toBe(1)
-  await expect(itemsLocator).toContainText('1 issue of type missing column')
+  await expect(itemsLocator).toContainText('description column is missing')
   await expect(page.getByText('How to improve Adur District Council’s data')).toBeVisible()
 
   // verify we get correctly routed to a 404

--- a/test/acceptance/request_check.test.js
+++ b/test/acceptance/request_check.test.js
@@ -50,7 +50,7 @@ async function checkDataFile ({ page, jsEnabled }) {
   let resultsPage
   if (jsEnabled) {
     resultsPage = await statusPage.clickContinue()
-    resultsPage.expectPageHasTabs(false)
+    resultsPage.expectPageHasTabs(jsEnabled)
   } else {
     await page.waitForTimeout(5000)
     resultsPage = await statusPage.clickCheckStatusButton()

--- a/test/integration/pages_load_ok.playwright.test.js
+++ b/test/integration/pages_load_ok.playwright.test.js
@@ -153,7 +153,7 @@ test.describe('status and results', () => {
     const resultsPage = new ResultsPage(page)
     await resultsPage.navigateToRequest('completed')
     await new Promise(resolve => setTimeout(resolve, 500))
-    expect(page.url()).toContain('/results/completed/0')
+    expect(page.url()).toContain('/results/completed/1')
   })
 
   // ToDo: just waiting on Alex's 404 page

--- a/test/unit/issueDetailsController.test.js
+++ b/test/unit/issueDetailsController.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest'
+import { prepareTask } from '../../src/controllers/issueDetailsController'
+
+describe('issueDetailsController', () => {
+  const reqTemplate = {
+    locals: {},
+    aggregatedTasks: new Map([
+      ['missing column|name', { field: 'name' }]]),
+    params: { issueType: 'missing column', field: 'name' },
+    totalRows: 10
+  }
+
+  it('missing columns issue produces useful message', () => {
+    const req = structuredClone(reqTemplate)
+    const next = vi.fn()
+    prepareTask(req, {}, next)
+    expect(req.locals.task.message).toBe('<span class="column-name">name</span> column is missing')
+  })
+
+  it('produces useful message for field issues', () => {
+    const req = structuredClone(reqTemplate)
+    req.params = { issueType: 'invalid flag', field: 'some flag' }
+    req.aggregatedTasks.set(`${req.params.issueType}|${req.params.field}`, {
+      ...req.params, count: 2
+    })
+    const next = vi.fn()
+    prepareTask(req, {}, next)
+    expect(req.locals.task.message.trim()).toBe('2 entries have <span class="column-name">some flag</span> fields that must have valid YES or NO values')
+  })
+})

--- a/test/unit/middleware/common.middleware.test.js
+++ b/test/unit/middleware/common.middleware.test.js
@@ -1387,7 +1387,7 @@ describe('preventIndexing middleware', () => {
     expect(res.set).toBeCalledWith('X-Robots-Tag', 'noindex')
   })
   it('should set headers on the check tool results page', () => {
-    const req = { originalUrl: '/check/results/PHvgmEPg4EQWGvr646vuMz/0' }
+    const req = { originalUrl: '/check/results/PHvgmEPg4EQWGvr646vuMz/1' }
     const res = { set: vi.fn() }
     preventIndexing(req, res, vi.fn())
     expect(res.set).toBeCalledWith('X-Robots-Tag', 'noindex')

--- a/test/unit/performanceDbApi.test.js
+++ b/test/unit/performanceDbApi.test.js
@@ -70,6 +70,12 @@ describe('performanceDbApi', () => {
     it('returns a message with the correct field replacement', () => {
       const message = performanceDbApi.getTaskMessage({ issue_type: 'some_issue_type', num_issues: 1, field: 'my_field' })
       expect(message).toContain('my_field')
+      expect(message).not.toContain('<span class="column-name>')
+    })
+
+    it('returns a message with HTML markup, when format=html option passed', () => {
+      const message = performanceDbApi.getTaskMessage({ issue_type: 'some_issue_type', num_issues: 1, field: 'my_field', format: 'html' })
+      expect(message).toContain('<span class="column-name">my_field</span>')
     })
 
     it('returns a singular message for num_issues === 1', () => {

--- a/test/unit/performanceDbApi.test.js
+++ b/test/unit/performanceDbApi.test.js
@@ -70,7 +70,7 @@ describe('performanceDbApi', () => {
     it('returns a message with the correct field replacement', () => {
       const message = performanceDbApi.getTaskMessage({ issue_type: 'some_issue_type', num_issues: 1, field: 'my_field' })
       expect(message).toContain('my_field')
-      expect(message).not.toContain('<span class="column-name>')
+      expect(message).not.toContain('<span class="column-name">')
     })
 
     it('returns a message with HTML markup, when format=html option passed', () => {

--- a/test/unit/publishRequestAPI.test.js
+++ b/test/unit/publishRequestAPI.test.js
@@ -103,7 +103,7 @@ describe('asyncRequestApi', () => {
 
       const result = await getRequestData(resultId)
 
-      expect(axios.get).toHaveBeenCalledWith(expectedUrl)
+      expect(axios.get).toHaveBeenCalledWith(new URL(expectedUrl))
       expect(result).toBeInstanceOf(RequestData)
     })
 

--- a/test/unit/requestData.test.js
+++ b/test/unit/requestData.test.js
@@ -69,7 +69,7 @@ describe('RequestData', () => {
       }
       const requestData = new RequestData(response)
 
-      await requestData.fetchResponseDetails(0, 50, 'error')
+      await requestData.fetchResponseDetails(0, 50, { severity: 'error' })
 
       expect(axios.get).toHaveBeenCalledWith(`http://localhost:8001/requests/1/response-details?offset=0&limit=50&jsonpath=${encodeURIComponent('$.issue_logs[*].severity=="error"')}`, { timeout: 30000 })
     })

--- a/test/unit/requestData.test.js
+++ b/test/unit/requestData.test.js
@@ -48,7 +48,8 @@ describe('RequestData', () => {
         'error-summary': ['error1', 'error2']
       })
 
-      expect(axios.get).toHaveBeenCalledWith('http://localhost:8001/requests/1/response-details?offset=0&limit=50', { timeout: 30000 })
+      const url = new URL('http://localhost:8001/requests/1/response-details?offset=0&limit=50')
+      expect(axios.get).toHaveBeenCalledWith(url, { timeout: 30000 })
     })
 
     it('correctly sets the jsonpath if severity is provided', async () => {
@@ -70,8 +71,9 @@ describe('RequestData', () => {
       const requestData = new RequestData(response)
 
       await requestData.fetchResponseDetails(0, 50, { severity: 'error' })
+      const url = new URL(`http://localhost:8001/requests/1/response-details?offset=0&limit=50&jsonpath=${encodeURIComponent('$.issue_logs[*].severity=="error"')}`)
 
-      expect(axios.get).toHaveBeenCalledWith(`http://localhost:8001/requests/1/response-details?offset=0&limit=50&jsonpath=${encodeURIComponent('$.issue_logs[*].severity=="error"')}`, { timeout: 30000 })
+      expect(axios.get).toHaveBeenCalledWith(url, { timeout: 30000 })
     })
   })
 

--- a/test/unit/responseDetails.test.js
+++ b/test/unit/responseDetails.test.js
@@ -298,24 +298,24 @@ describe('ResponseDetails', () => {
         id: 'test'
       }
 
-      const result = ResponseDetails.prototype.getPagination.call(instance, 5)
+      const result = ResponseDetails.prototype.getPagination.call(instance, 6)
 
       expect(result).toEqual({
         totalResults: 100,
         offset: 0,
         limit: 10,
         currentPage: 6,
-        nextPage: 6,
-        previousPage: 4,
+        nextPage: 7,
+        previousPage: 5,
         totalPages: 10,
         items: [
-          { number: 1, href: '/check/results/test/0', current: false },
+          { number: 1, href: '/check/results/test/1', current: false },
           { ellipsis: true, href: '#' },
-          { number: 5, href: '/check/results/test/4', current: false },
-          { number: 6, href: '/check/results/test/5', current: true },
-          { number: 7, href: '/check/results/test/6', current: false },
+          { number: 5, href: '/check/results/test/5', current: false },
+          { number: 6, href: '/check/results/test/6', current: true },
+          { number: 7, href: '/check/results/test/7', current: false },
           { ellipsis: true, href: '#' },
-          { number: 10, href: '/check/results/test/9', current: false }
+          { number: 10, href: '/check/results/test/10', current: false }
         ]
       })
     })
@@ -329,21 +329,21 @@ describe('ResponseDetails', () => {
         },
         id: 'test'
       }
-      const result = ResponseDetails.prototype.getPagination.call(instance, 9)
+      const result = ResponseDetails.prototype.getPagination.call(instance, 10)
       expect(result).toEqual({
         totalResults: 100,
         offset: 90,
         limit: 10,
         currentPage: 10,
         nextPage: null,
-        previousPage: 8,
+        previousPage: 9,
         totalPages: 10,
         items: [
-          { number: 1, href: '/check/results/test/0', current: false },
+          { number: 1, href: '/check/results/test/1', current: false },
           { ellipsis: true, href: '#' },
-          { number: 8, href: '/check/results/test/7', current: false },
-          { number: 9, href: '/check/results/test/8', current: false },
-          { number: 10, href: '/check/results/test/9', current: true }
+          { number: 8, href: '/check/results/test/8', current: false },
+          { number: 9, href: '/check/results/test/9', current: false },
+          { number: 10, href: '/check/results/test/10', current: true }
         ]
       })
     })
@@ -357,21 +357,21 @@ describe('ResponseDetails', () => {
         },
         id: 'test'
       }
-      const result = ResponseDetails.prototype.getPagination.call(instance, 0)
+      const result = ResponseDetails.prototype.getPagination.call(instance, 1)
       expect(result).toEqual({
         totalResults: 100,
         offset: 0,
         limit: 10,
         currentPage: 1,
-        nextPage: 1,
+        nextPage: 2,
         previousPage: null,
         totalPages: 10,
         items: [
-          { number: 1, href: '/check/results/test/0', current: true },
-          { number: 2, href: '/check/results/test/1', current: false },
-          { number: 3, href: '/check/results/test/2', current: false },
+          { number: 1, href: '/check/results/test/1', current: true },
+          { number: 2, href: '/check/results/test/2', current: false },
+          { number: 3, href: '/check/results/test/3', current: false },
           { ellipsis: true, href: '#' },
-          { number: 10, href: '/check/results/test/9', current: false }
+          { number: 10, href: '/check/results/test/10', current: false }
         ]
       })
     })

--- a/test/unit/resultsController.test.js
+++ b/test/unit/resultsController.test.js
@@ -14,6 +14,7 @@ vi.mock('../../src/filters/prettifyColumnName', () => ({
 
 const mockRequest = () => ({
   params: { id: '123', pageNumber: '1' },
+  parsedParams: { pageNumber: 1 },
   locals: {},
   form: { options: {} }
 })

--- a/test/unit/shareResultsController.test.js
+++ b/test/unit/shareResultsController.test.js
@@ -32,7 +32,7 @@ describe('ShareResultsController', () => {
     it('should set shareLink in req.locals and req.form.options', async () => {
       await shareResultsController.locals(req, res, next)
 
-      const expectedLink = `${config.url}check/results/123/0`
+      const expectedLink = `${config.url}check/results/123/1`
       expect(req.locals.shareLink).toBe(expectedLink)
       expect(req.form.options.shareLink).toBe(expectedLink)
     })
@@ -40,7 +40,7 @@ describe('ShareResultsController', () => {
     it('should set backLink and backLinkText in options', async () => {
       await shareResultsController.locals(req, res, next)
 
-      const expectedLink = `${config.url}check/results/123/0`
+      const expectedLink = `${config.url}check/results/123/1`
       expect(shareResultsController.options.backLink).toBe(expectedLink)
       expect(shareResultsController.options.backLinkText).toBe('Back to results')
     })
@@ -68,7 +68,7 @@ describe('ShareResultsController', () => {
   describe('generateResultsLink', () => {
     it('should generate correct results link', () => {
       const link = shareResultsController.generateResultsLink('456')
-      expect(link).toBe(`${config.url}check/results/456/0`)
+      expect(link).toBe(`${config.url}check/results/456/1`)
     })
 
     it('should handle different id formats', () => {
@@ -76,7 +76,7 @@ describe('ShareResultsController', () => {
 
       testCases.forEach(id => {
         const link = shareResultsController.generateResultsLink(id)
-        expect(link).toBe(`${config.url}check/results/${id}/0`)
+        expect(link).toBe(`${config.url}check/results/${id}/1`)
       })
     })
   })


### PR DESCRIPTION
## Preview Link

https://submit-pr-892.herokuapp.com/

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature

## Description

Adds issue details page to the check tool results.  

As [discussed](https://github.com/digital-land/submit/issues/786#issuecomment-2647864781), the table, to be actually useful, needs changes on the API side - currently it shows all data (as opposed, just the data relevant to the viewed issue).

Also:
- refactors some of the acceptance tests to remove duplication

## Related Tickets & Documents
 
- Closes #859
- Part of #786 
- Next: #897 

## QA Instructions, Screenshots, Recordings

Go to preview link, submit an URL (with some data issues) and click through to an issue from the results page.

_Note_: the column names and order in the table are fixed in #897

![image](https://github.com/user-attachments/assets/e199a11d-1aaa-4fe0-ad20-aef51ab5f46e)


## Added/updated tests?

- [x] Yes

## QA sign off
- [ ] Code has been checked and approved
- [ ] Design has been checked and approved
- [ ] Product and business logic has been checked and proved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a feature to display links to individual issue pages on the results page.
  - Added a new HTML template for viewing detailed issue information related to datasets.
  
- **Style**
  - Enhanced error messages by applying bold formatting to key details, improving readability across the interface.

- **Bug Fixes**
  - Updated pagination logic to ensure correct navigation, with page numbers now starting at 1.
  - Improved URL handling in various components to reflect the new pagination structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->