### PR TITLE
pass in empty string if no resources are defined

### DIFF
--- a/src/middleware/entryIssueDetails.middleware.js
+++ b/src/middleware/entryIssueDetails.middleware.js
@@ -46,7 +46,7 @@ const fetchIssueCount = fetchOne({
     select count(*) as count
     from issue i
     LEFT JOIN issue_type it ON i.issue_type = it.issue_type
-    WHERE resource = '${req.resources[0].resource}'
+    WHERE resource = '${req.resources[0]?.resource || ''}'
     AND i.issue_type = '${params.issue_type}'
     AND it.responsibility = 'external'
     AND field = '${params.issue_field}'


### PR DESCRIPTION
## Preview Link
https://submit-pr-[PR_NUMBER].herokuapp.com/

## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR addresses a potential issue with accessing the `resource` property of `req.resources[0]`. The change ensures that if `req.resources[0]` is undefined, the query will not break by providing a default empty string. This improves the robustness of the SQL query in the `fetchIssueCount` function.
if no resources are defined, the middleware chain will go on to find now issues and therefor show a 404 page instead of a generic error page

## Related Tickets & Documents
- Ticket Link #763 

## QA Instructions, Screenshots, Recordings

navigating to here: /organisations/local-authority:BUC/tree-preservation-order/reference%20values%20are%20not%20unique/reference/entry/368
now shows a 404 instead of a general error

## Added/updated tests?
- [ ] Yes
- [x] No, and this is why: The change is a minor bug fix that does not require additional tests.
- [ ] I need help with writing tests

## QA sign off
- [ ] Code has been checked and approved
- [ ] Design has been checked and approved
- [ ] Product and business logic has been checked and proved