### PR TITLE
JSDocs tweaks

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './docs'
+          path: './github-pages'
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,5 @@ uploads/*
 # Ignore npm audit report file(static-audit)
 npm-audit-report.json 
 .cursor/rules/*
+
+github-pages

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -4,7 +4,7 @@
     "includePattern": ".+\\.js$",
     "excludePattern": "(node_modules/|test/)"
   },
-  "plugins": ["plugins/markdown"],
+  "plugins": ["plugins/markdown", "node_modules/jsdoc-tsimport-plugin"],
   "opts": {
     "destination": "./github-pages",
     "recurse": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "concurrently": "^8.2.2",
         "husky": "^9.0.11",
         "jsdoc": "^4.0.4",
+        "jsdoc-tsimport-plugin": "^1.0.5",
         "jsdom": "^24.1.0",
         "json-schema-faker": "^0.5.6",
         "nodemon": "^3.0.1",
@@ -11230,6 +11231,13 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/jsdoc-tsimport-plugin": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/jsdoc-tsimport-plugin/-/jsdoc-tsimport-plugin-1.0.5.tgz",
+      "integrity": "sha512-6mvyF+tXdanf3zxEumTF9Uf/sXGlANP+XohSuiJiOVVWPGxi+3f2a2sy5Ew3W+0PMYUkcGYNxfYd5mMZsIHQpg==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/jsdoc/node_modules/escape-string-regexp": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "concurrently": "^8.2.2",
     "husky": "^9.0.11",
     "jsdoc": "^4.0.4",
+    "jsdoc-tsimport-plugin": "^1.0.5",
     "jsdom": "^24.1.0",
     "json-schema-faker": "^0.5.6",
     "nodemon": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "playwright-codegen": "playwright codegen http://localhost:5000",
     "lint": "standard",
     "lint:fix": "standard --fix",
-    "generate:docs": "jsdoc -c jsdoc.json"
+    "generate:docs": "jsdoc -c jsdoc.json -u ./docs"
   },
   "engines": {
     "node": ">=22.5.1"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Documentation Update

## Description

- Fixes github actions configuration
- Includes markdown files in our `docs` in the generated docs
- Adds JSDoc plugin to handle import statements in comments, e.g. `@param {import('express').Request} req - request object`

## Related Tickets & Documents

- Related #898

## Added/updated tests?

- [x] No; this is documentation only update

