### PR TITLE
dataset overview and tasks list pages: include failed oob expectations

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -50,24 +50,53 @@ contact:
 datasetsConfig:
   article-4-direction:
     guidanceUrl: /guidance/specifications/article-4-direction
+    entityDisplayName:
+      base: article 4 direction
+      variable: area
   article-4-direction-area:
     guidanceUrl: /guidance/specifications/article-4-direction
+    entityDisplayName:
+      base: article 4 direction
+      variable: area
   brownfield-land:
     guidanceUrl: https://www.gov.uk/government/publications/brownfield-land-registers-data-standard/publish-your-brownfield-land-data
+    entityDisplayName:
+      base: brownfield
+      variable: land
   conservation-area:
     guidanceUrl: /guidance/specifications/conservation-area
+    entityDisplayName:
+      base: conservation
+      variable: area
   conservation-area-document:
     guidanceUrl: /guidance/specifications/conservation-area
+    entityDisplayName:
+      base: conservation
+      variable: area
   tree-preservation-order:
     guidanceUrl: /guidance/specifications/tree-preservation-order
+    entityDisplayName:
+      base: tree preservation
+      variable: order
   tree-preservation-zone:
     guidanceUrl: /guidance/specifications/tree-preservation-order
+    entityDisplayName:
+      base: tree preservation
+      variable: zone
   tree:
     guidanceUrl: /guidance/specifications/tree-preservation-order
+    entityDisplayName:
+      variable: tree
   listed-building:
     guidanceUrl: /guidance/specifications/listed-building
+    entityDisplayName:
+      base: listed
+      variable: building
   listed-building-outline:
     guidanceUrl: /guidance/specifications/listed-building
+    entityDisplayName:
+      base: listed building
+      variable: outline
 tablePageLength: 50
 jira: {
   requestTypeId: 1

--- a/src/middleware/common.middleware.js
+++ b/src/middleware/common.middleware.js
@@ -850,6 +850,11 @@ export function noop (req, res, next) {
   next()
 }
 
+const expectationsOutOfBoundsDetailsSelectClause = () => {
+  return `CAST(JSON_EXTRACT(details, '$.actual') AS INTEGER) AS actual,
+          CAST(JSON_EXTRACT(details, '$.expected') AS INTEGER) AS expected`
+}
+
 const expectationsQuery = ({ lpa, dataset, expectation, includeDetails }) => {
   let datasetClause = ''
   if (dataset) {
@@ -857,7 +862,7 @@ const expectationsQuery = ({ lpa, dataset, expectation, includeDetails }) => {
   }
 
   return /* sql */ `
-  select dataset, name, passed, severity ${includeDetails ? ', details' : ''}
+  select dataset, name, passed, severity ${includeDetails ? ', ' + expectationsOutOfBoundsDetailsSelectClause() : ''}
   from expectation
   where 
      passed = 'False'

--- a/src/middleware/datasetTaskList.middleware.js
+++ b/src/middleware/datasetTaskList.middleware.js
@@ -1,10 +1,28 @@
+/**
+ * @module middleware-dataset-tasklist
+ *
+ * @description Middleware responsible for assembling and presenting a dataset's task list.
+ *
+ * The notion of "tasks" used here means some actions that an LPA needs to take to improve
+ * the quality of the data.
+ *
+ * A task is added to the list when:
+ * - data ingestion pipeline has problems accessing the endpoint URL (this happens outside of this application)
+ * - data ingestion pipeline found issues with the data (again, happnes outside of this application,
+ *   but we can query the results in datasette)
+ * - an 'expectation' failed (happens outside this application, but we can query the results)
+ */
+
 import {
   addEntityCountsToResources,
+  expectationFetcher,
+  expectations,
   fetchDatasetInfo,
   fetchEntityIssueCounts,
   fetchEntryIssueCounts,
   fetchOrgInfo, fetchResources, fetchSources,
   logPageError,
+  noop,
   processEntitiesMiddlewares,
   validateOrgAndDatasetQueryParams
 } from './common.middleware.js'
@@ -13,7 +31,8 @@ import performanceDbApi from '../services/performanceDbApi.js'
 import { statusToTagClass } from '../filters/filters.js'
 import '../types/datasette.js'
 import logger from '../utils/logger.js'
-import { types } from 'util'
+import { types } from '../utils/logging.js'
+import { isFeatureEnabled } from '../utils/features.js'
 
 /**
  * Fetches the resource status
@@ -21,6 +40,12 @@ import { types } from 'util'
 export const fetchResourceStatus = fetchOne({
   query: ({ params }) => performanceDbApi.resourceStatusQuery(params.lpa, params.dataset),
   result: 'resourceStatus'
+})
+
+const fetchOutOfBoundsExpectations = expectationFetcher({
+  expectation: expectations.entitiesOutOfBounds,
+  includeDetails: true,
+  result: 'expectationOutOfBounds'
 })
 
 /**
@@ -43,15 +68,22 @@ const SPECIAL_ISSUE_TYPES = ['reference values are not unique']
 /**
  * Generates a list of tasks based on the issues found in the dataset.
  *
- * @param {Object} req - The request object. It should contain the following properties:
- *   - {Object} parsedParams: An object containing the parameters of the request. It should have the following properties:
- *     - {string} lpa: The LPA (Local Planning Authority) associated with the request.
- *     - {string} dataset: The name of the dataset associated with the request.
- *   - {Array} entities: An array of entity objects.
- *   - {Array} resources: An array of resource objects.
- *   - {Array} sources: An array of source objects.
- *   - {Object} entryIssueCounts: An object containing the issue counts for the entries in the dataset.
- *   - {Object} entityIssueCounts: An object containing the issue counts for the entities in the dataset.
+ * @param {Object} req The request object. It should contain the following properties:
+ * @param {Object} req.parsedParams An object containing the parameters of the request
+ * @param {string} req.parsedParams.lpa The LPA (Local Planning Authority) associated with the request.
+ * @param {string} req.parsedParams.dataset The name of the dataset associated with the request.
+ * @param {Object[]} req.entities: An array of entity objects.
+ * @param {Object[]} req.resources: An array of resource objects.
+ * @param {Object[]} req.sources: An array of source objects.
+ * @param {Object} req.entryIssueCounts: An object containing the issue counts for the entries in the dataset.
+ * @param {Object} req.entityIssueCounts: An object containing the issue counts for the entities in the dataset.
+ * @param {Object[]} [req.expectationOutOfBounds]
+ * @param {string} req.expectationOutOfBounds[].dataset
+ * @param {boolean} req.expectationOutOfBounds[].passed did the exepectation pass
+ * @param {Object} req.expectationOutOfBounds[].details JSON blob
+ * @param {number} req.expectationOutOfBounds[].details.expected
+ * @param {number} req.expectationOutOfBounds[].details.actual
+ * @param {Object} req.taskList OUT value
  * @param {Object} res - The response object.
  * @param {Function} next - The next middleware function.
  * @returns {undefined}
@@ -59,7 +91,7 @@ const SPECIAL_ISSUE_TYPES = ['reference values are not unique']
 export const prepareTasks = (req, res, next) => {
   const { lpa, dataset } = req.parsedParams
   const { entities, resources, sources } = req
-  const { entryIssueCounts, entityIssueCounts } = req
+  const { entryIssueCounts, entityIssueCounts, expectationOutOfBounds = [] } = req
 
   const entityCount = entities.length
   let issues = [...entryIssueCounts, ...entityIssueCounts]
@@ -118,6 +150,16 @@ export const prepareTasks = (req, res, next) => {
     }
   }
 
+  if (expectationOutOfBounds.length > 0) {
+    taskList.push({
+      title: {
+        text: 'There are entities outside the boundary'
+      },
+      href: '', // NOTE: design for 'expectation' task detail page not ready yet
+      status: getStatusTag('Needs fixing')
+    })
+  }
+
   req.taskList = taskList
 
   next()
@@ -126,10 +168,17 @@ export const prepareTasks = (req, res, next) => {
 /**
  * Middleware. Updates req with `templateParams`
  *
- * @param {{ orgInfo: OrgInfo, sources: Source[], entityCountRow: undefined | { entity_count: number}, issues: Issue[] }} req
+ * param {{ orgInfo: OrgInfo, sources: Source[], entityCountRow: undefined | { entity_count: number}, issues: Issue[] }} req
+ * @param {Object} req request
+ * @param {Object} req.orgInfo organisation info
+ * @param {Object} req.dataset dataset info
+ * @param {Object} req.sources sources
+ * @param {Object} [req.entityCountRow] contains `{ entity_count: number }`
+ * @param {Object[]} req.issues dataset issues
+ * @param {Object[]} req.taskList task list
+ * @param {Object} [req.templateParams] OUT param
  * @param {*} res
  * @param {*} next
- * @returns { { templateParams: object }}
  */
 export const prepareDatasetTaskListTemplateParams = (req, res, next) => {
   const { taskList, dataset, orgInfo: organisation } = req
@@ -154,6 +203,7 @@ export default [
   fetchSources,
   fetchDatasetInfo,
   fetchResources,
+  isFeatureEnabled('expectactionOutOfBoundsTask') ? fetchOutOfBoundsExpectations : noop,
   addEntityCountsToResources,
   ...processEntitiesMiddlewares,
   fetchEntityIssueCounts,

--- a/test/unit/middleware/datasetOverview.middleware.test.js
+++ b/test/unit/middleware/datasetOverview.middleware.test.js
@@ -25,6 +25,7 @@ describe('Dataset Overview Middleware', () => {
         datasetSpecification: { fields: [{ field: 'field1' }, { field: 'field2' }] },
         columnSummary: [{ mapping_field: 'field1', non_mapping_field: 'field3' }],
         entityCount: { entity_count: 10 },
+        expectationOutOfBounds: [{ dataset: req.params.dataset, passed: 'False' }],
         sources: [
           { endpoint: 'endpoint1', endpoint_url: 'endpoint1', documentation_url: 'doc-url1', status: 200, endpoint_entry_date: 'LU1', latest_log_entry_date: 'LA1', resource_start_date: '2023-01-01' },
           { endpoint: 'endpoint2', endpoint_url: 'endpoint2', documentation_url: 'doc-url2', status: 404, exception: 'exception', endpoint_entry_date: 'LU2', latest_log_entry_date: 'LA2', resource_start_date: '2023-01-02' }
@@ -45,7 +46,7 @@ describe('Dataset Overview Middleware', () => {
       expect(reqWithResults.templateParams).toEqual({
         organisation: { name: 'mock-org' },
         dataset: reqWithResults.dataset,
-        taskCount: 2, // 1 issue + 1 endpoint error
+        taskCount: 3, // 1 issue + 1 endpoint error + 1 failed 'out of bound' expectation
         stats: {
           numberOfFieldsSupplied: 1,
           numberOfFieldsMatched: 1,

--- a/test/unit/middleware/datasetTaskList.middleware.test.js
+++ b/test/unit/middleware/datasetTaskList.middleware.test.js
@@ -1,7 +1,7 @@
 import * as v from 'valibot'
 import * as S from '../../../src/routes/schemas.js'
 import { describe, it, vi, expect } from 'vitest'
-import { prepareDatasetTaskListTemplateParams, prepareTasks } from '../../../src/middleware/datasetTaskList.middleware.js'
+import { prepareDatasetTaskListTemplateParams, prepareTasks, entityOutOfBoundsMessage } from '../../../src/middleware/datasetTaskList.middleware.js'
 import performanceDbApi from '../../../src/services/performanceDbApi.js'
 
 vi.mock('../../../src/services/performanceDbApi.js')
@@ -279,5 +279,28 @@ describe('datasetTaskList.middleware.js', () => {
 
       expect(next).toHaveBeenCalledTimes(1)
     })
+  })
+})
+
+describe('entityOutOfBoundsMessage()', () => {
+  it('handles not configured dataset', () => {
+    expect(entityOutOfBoundsMessage('new-dataset', 1)).toBe('You have 1 entity outside of your boundary')
+    expect(entityOutOfBoundsMessage('new-dataset', 9)).toBe('You have 9 entities outside of your boundary')
+  })
+  it('correctly displays configured dataset', () => {
+    expect(entityOutOfBoundsMessage('article-4-direction', 2)).toBe('You have 2 article 4 direction areas outside of your boundary')
+    expect(entityOutOfBoundsMessage('article-4-direction-area', 2)).toBe('You have 2 article 4 direction areas outside of your boundary')
+    expect(entityOutOfBoundsMessage('brownfield-land', 2)).toBe('You have 2 brownfield lands outside of your boundary')
+    expect(entityOutOfBoundsMessage('conservation-area', 2)).toBe('You have 2 conservation areas outside of your boundary')
+    expect(entityOutOfBoundsMessage('conservation-area-document', 2)).toBe('You have 2 conservation areas outside of your boundary')
+    expect(entityOutOfBoundsMessage('tree-preservation-order', 2)).toBe('You have 2 tree preservation orders outside of your boundary')
+    expect(entityOutOfBoundsMessage('tree-preservation-zone', 2)).toBe('You have 2 tree preservation zones outside of your boundary')
+    expect(entityOutOfBoundsMessage('tree', 2)).toBe('You have 2 trees outside of your boundary')
+    expect(entityOutOfBoundsMessage('listed-building', 2)).toBe('You have 2 listed buildings outside of your boundary')
+    expect(entityOutOfBoundsMessage('listed-building-outline', 2)).toBe('You have 2 listed building outlines outside of your boundary')
+  })
+  it('Handles missing count', () => {
+    expect(entityOutOfBoundsMessage('conservation-area', undefined)).toBe('You have conservation areas outside of your boundary')
+    expect(entityOutOfBoundsMessage('new-dataset', undefined)).toBe('You have entities outside of your boundary')
   })
 })


### PR DESCRIPTION
## Preview Link

https://submit-pr-951.herokuapp.com/

## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Updates the dataset overview and task list to count failed out of bounds expectations as "tasks" for the LPA.

## Related Tickets & Documents

- Issue #921 
- Follow up to #948 

## QA Instructions, Screenshots, Recordings

Below is an example "out of bounds" task.

_Note_: the task does not link to an issue page, that's a separate PR. 

![image](https://github.com/user-attachments/assets/61415b15-012d-4118-8f3e-7e297bc626fe)

## Added/updated tests?

- [x] Yes

## QA sign off
- [ ] Code has been checked and approved
- [ ] Design has been checked and approved
- [ ] Product and business logic has been checked and proved



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Task messages now dynamically reflect counts of out-of-bound items, ensuring users receive accurate status updates.
	- An integrated issue guidance section has been added to provide clear, actionable instructions for resolving missing data columns.
  
- **Enhancements**
	- Dataset labels are now more descriptive, improving clarity and user navigation.
	- The layout on issue details pages has been refined to align with contemporary design standards and better support user needs.
  
- **Tests**
	- Expanded testing ensures the new guidance content renders correctly across different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->