### PR TITLE
Update http-error.html

### DIFF
--- a/src/views/organisations/http-error.html
+++ b/src/views/organisations/http-error.html
@@ -95,7 +95,7 @@
 
     <p>If your endpoint URL has changed you can <a class="resubmit-link" href="{{ organisation | endpointSubmissionFormToolDeepLink(dataset) }}">resubmit your endpoint URL</a>.</p>
 
-    <p>If your endpoint URL is no longer active, let us know by emailing digitalland@communities.gov.uk. We will retire it.</p>
+    <p>If your endpoint URL is no longer active, let us know by emailing <a href="mailto:digitalland@communities.gov.uk">digitalland@communities.gov.uk</a>. We will retire it.</p>
 
     <p>You should try to make sure your endpoint URLs stay the same when you update your data so we can collect your data
       each night.</p>

--- a/src/views/organisations/http-error.html
+++ b/src/views/organisations/http-error.html
@@ -46,8 +46,13 @@
       Error accessing endpoint URL
     </h2>
 
-    <p>There was an error accessing the endpoint URL. Please check the URL is correct and your API is functioning correctly.
-    </p>
+    <p>There was an error accessing the endpoint URL. Possible reasons for this error could be:</p>
+    
+    <ul class="govuk-list govuk-list--bullet">
+      <li>the URL is incorrect</li>
+      <li>your API is not functioning correctly</li>
+      <li>the endpoint URL has changed</li>
+      <li>the endpoint URL is no longer active</li></ul>
 
     <h3 class="govuk-heading-m">Error details</h3>
 
@@ -89,6 +94,8 @@
     }) }}
 
     <p>If your endpoint URL has changed you can <a class="resubmit-link" href="{{ organisation | endpointSubmissionFormToolDeepLink(dataset) }}">resubmit your endpoint URL</a>.</p>
+
+    <p>If your endpoint URL is no longer active, let us know by emailing digitalland@communities.gov.uk. We will retire it.</p>
 
     <p>You should try to make sure your endpoint URLs stay the same when you update your data so we can collect your data
       each night.</p>


### PR DESCRIPTION
Added some additional content about emailing us to retire endpoints, and reformatted some text into bullet points.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description

Added some additional content about emailing us to retire endpoints, and reformatted some text into bullet points.

## Related Tickets & Documents

- Ticket Link - https://github.com/orgs/digital-land/projects/7/views/24?pane=issue&itemId=100321734&issue=digital-land%7Csubmit%7C946

Mocked this up in Mural but should look like this:

<img width="417" alt="Endpointerrorscreenshot" src="https://github.com/user-attachments/assets/a92486ee-546e-46b2-b312-b47cc824db7e" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the error message to provide a detailed breakdown of potential issues with accessing endpoint URLs, including reasons such as an incorrect URL, API problems, endpoint changes, or deactivation.
  - Added clear guidance advising users to contact the support team if their endpoint is no longer active for further assistance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->