### PR TITLE
Check tool: display all geometry

### DIFF
--- a/src/assets/js/map.js
+++ b/src/assets/js/map.js
@@ -142,7 +142,7 @@ export class Map {
     this.map.addSource(sourceName, source)
 
     this.map.addLayer({
-      id: 'dataset-thing',
+      id: 'dataset-poly',
       type: 'fill',
       source: sourceName,
       layout: {},
@@ -154,7 +154,7 @@ export class Map {
     }, this.firstMapLayerId)
 
     this.map.addLayer({
-      id: 'dataset-thing-border',
+      id: 'dataset-poly-border',
       type: 'line',
       source: sourceName,
       layout: {},
@@ -166,7 +166,7 @@ export class Map {
     })
 
     this.map.addLayer({
-      id: 'dataset-thing-point',
+      id: 'dataset-poly-point',
       type: 'circle',
       source: sourceName,
       paint: {

--- a/src/models/requestData.js
+++ b/src/models/requestData.js
@@ -152,7 +152,7 @@ function * offsets (limit, offset, maxOffset) {
  * @param {number} numTasks max number of tasks to run
  * @param {Object} gen offset generator
  * @param {Function} taskFactory (taskIndex, offset) => Promise<>
- * @returns
+ * @returns {Promise[]}
  */
 function startRequests (numTasks, gen, taskFactory) {
   const tasks = []

--- a/src/models/requestData.js
+++ b/src/models/requestData.js
@@ -61,7 +61,7 @@ export default class ResultData {
       urlTemplate.searchParams.delete('offset')
       urlTemplate.searchParams.delete('limit')
 
-      const paginationOpts = { limit: limit * 2, offset: response.data.length, maxOffset: Number.isInteger(totalResults) ? totalResults : 100 }
+      const paginationOpts = { limit, offset: response.data.length, maxOffset: Number.isInteger(totalResults) ? totalResults : 100 }
       const restResponses = await fetchPaginated(url, paginationOpts)
       responses.push(...restResponses.flatMap(resp => resp.data))
     }

--- a/test/unit/javascript/map.test.js
+++ b/test/unit/javascript/map.test.js
@@ -51,18 +51,19 @@ describe('map.js', () => {
 
       const map = new Map({ containerId: 'map', data: ['POINT (1 1)'], interactive: true, wktFormat: true })
 
-      expect(map.map.addSource).toHaveBeenCalledWith('geometry-0', {
+      expect(map.map.addSource).toHaveBeenCalledWith('dataset', {
         type: 'geojson',
         data: {
-          type: 'Feature',
-          geometry: { coordinates: [1, 1], type: 'Point' },
-          properties: {
-            geo: 'POINT (1 1)'
-          }
+          type: 'FeatureCollection',
+          features: [
+            {
+              type: 'Feature',
+              geometry: { coordinates: [1, 1], type: 'Point' }
+            }]
         }
       })
       expect(map.map.addLayer).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'circle', id: 'geometry-0' }),
+        expect.objectContaining({ type: 'fill', id: 'dataset-poly' }),
         'symbol-layer'
       )
     })
@@ -197,7 +198,8 @@ describe('map.js', () => {
 
     it('should default to maptiler style if token fetch fails', async () => {
       vi.mock('../../../src/assets/js/os-api-token.js', () => ({
-        getApiToken: vi.fn().mockRejectedValue(new Error('API token fetch failed'))
+        getApiToken: vi.fn().mockReturnValue(''),
+        getFreshApiToken: vi.fn().mockRejectedValue(new Error('API token fetch failed'))
       }))
 
       global.window.serverContext = {

--- a/test/unit/requestData.test.js
+++ b/test/unit/requestData.test.js
@@ -20,14 +20,22 @@ vi.spyOn(logger, 'error')
 describe('RequestData', () => {
   describe('fetchResponseDetails', () => {
     it('should return a new ResponseDetails object (paginated)', async () => {
-      axios.get.mockResolvedValue({
+      axios.get.mockResolvedValueOnce({
         headers: {
-          'x-pagination-total-results': '100',
+          'x-pagination-total-results': '2',
           'x-pagination-offset': '0',
-          'x-pagination-limit': '50'
+          'x-pagination-limit': '1'
         },
         data: [{ 'error-summary': ['error1', 'error2'] }]
       })
+        .mockResolvedValueOnce({
+          headers: {
+            'x-pagination-total-results': '2',
+            'x-pagination-offset': '1',
+            'x-pagination-limit': '1'
+          },
+          data: [{ 'error-summary': ['error1', 'error2'] }]
+        })
 
       const response = {
         id: 1,
@@ -35,17 +43,17 @@ describe('RequestData', () => {
       }
       const requestData = new RequestData(response)
 
-      const responseDetails = await requestData.fetchResponseDetails()
+      const responseDetails = await requestData.fetchResponseDetails(0, 1)
 
       expect(responseDetails).toBeInstanceOf(ResponseDetails)
 
-      expect(responseDetails.pagination.totalResults).toBe('100')
+      expect(responseDetails.pagination.totalResults).toBe('2')
       expect(responseDetails.pagination.offset).toBe('0')
-      expect(responseDetails.pagination.limit).toBe('100')
+      expect(responseDetails.pagination.limit).toBe('2')
       expect(responseDetails.response).toStrictEqual([
         { 'error-summary': ['error1', 'error2'] },
-        { 'error-summary': ['error1', 'error2'] }]
-      )
+        { 'error-summary': ['error1', 'error2'] }
+      ])
     })
 
     it('should return a new ResponseDetails object', async () => {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature
- [x] Refactor
- [x] Optimization

## Description

The check tool results page displayed geometry from first 50 records only. This change updates the code to fetch all the records (there may be thousands of them), it also updates the client map code to avoid creating thousands of layers (which causes performance issues - map becomes unresponsive). 

## Related Tickets & Documents

- Related Issue #960 
- Closes #1005 

## QA Instructions, Screenshots, Recordings

Note: since we fetch all the records - there's no longer a need for pagination under the table.

Try submit this [Article 4 direction area](https://services2.arcgis.com/LrUbY6lLLgV3tEa5/arcgis/rest/services/Listed_Buildings_Public/FeatureServer/0/query?f=geojson&outFields=*&where=1%3D1) data with the check tool. 

## Added/updated tests?

- [x] Yes

## QA sign off
- [ ] Code has been checked and approved
- [ ] Design has been checked and approved
- [ ] Product and business logic has been checked and proved



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced data fetching to automatically retrieve all paginated results in parallel, providing complete datasets without manual pagination.
- **Refactor**
	- Simplified map rendering by consolidating all geometries into a single source and using type-based layers for polygons, lines, and points.
- **Tests**
	- Updated and expanded tests to cover new pagination logic and consolidated map layers, ensuring accurate and reliable behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->