### PR TITLE
fix: show 404 when no issues fetched on entity page

### DIFF
--- a/src/middleware/entityIssueDetails.middleware.js
+++ b/src/middleware/entityIssueDetails.middleware.js
@@ -1,3 +1,4 @@
+import { MiddlewareError } from '../utils/errors.js'
 import { issueErrorMessageHtml } from '../utils/utils.js'
 import {
   fetchDatasetInfo,
@@ -139,6 +140,24 @@ export function prepareEntity (req, res, next) {
 }
 
 /**
+ *
+ * @param {Object} req request
+ * @param {number} req.recordCount
+ * @param {Object} res response
+ * @param {Function} next next function
+ * @returns
+ */
+export const show404ifNoIssues = (req, res, next) => {
+  const { recordCount } = req
+  if (recordCount === 0) {
+    // possibly accessing an outdated URL
+    return next(new MiddlewareError('no issues found', 404))
+  }
+
+  next()
+}
+
+/**
  * Middleware. Renders the issue details page with the list of issues, entry data,
  * and organisation and dataset details.
  */
@@ -159,6 +178,7 @@ export default [
   getIssueSpecification,
   filterOutEntitiesWithoutIssues,
   setRecordCount,
+  show404ifNoIssues,
   getSetDataRange(1),
   show404IfPageNumberNotInRange,
   getSetBaseSubPath(['entity']),

--- a/src/middleware/entityIssueDetails.middleware.js
+++ b/src/middleware/entityIssueDetails.middleware.js
@@ -145,7 +145,7 @@ export function prepareEntity (req, res, next) {
  * @param {number} req.recordCount
  * @param {Object} res response
  * @param {Function} next next function
- * @returns
+ * @returns {undefined}
  */
 export const show404ifNoIssues = (req, res, next) => {
   const { recordCount } = req

--- a/test/unit/middleware/entityIssueDetails.middleware.test.js
+++ b/test/unit/middleware/entityIssueDetails.middleware.test.js
@@ -1,5 +1,6 @@
 import { describe, it, vi, expect, beforeEach } from 'vitest'
-import { getIssueDetails, getIssueField, prepareEntity, setRecordCount } from '../../../src/middleware/entityIssueDetails.middleware.js'
+import { getIssueDetails, getIssueField, prepareEntity, setRecordCount, show404ifNoIssues } from '../../../src/middleware/entityIssueDetails.middleware.js'
+import { MiddlewareError } from '../../../src/utils/errors.js'
 
 vi.mock('../../../src/services/performanceDbApi.js')
 
@@ -227,6 +228,18 @@ describe('issueDetails.middleware.js', () => {
 
       expect(res.render).toHaveBeenCalledTimes(1)
       expect(res.render).toHaveBeenCalledWith('organisations/issueDetails.html', req.templateParams)
+    })
+  })
+
+  describe('show404ifNoIssues', () => {
+    it('raises 404 when on issues found', () => {
+      let next = vi.fn()
+      show404ifNoIssues({ recordCount: 0 }, {}, next)
+      expect(next).toHaveBeenCalledWith(new MiddlewareError('no issues found', 404))
+
+      next = vi.fn()
+      show404ifNoIssues({ recordCount: 10 }, {}, next)
+      expect(next).toHaveBeenCalledWith()
     })
   })
 })

--- a/test/unit/middleware/entityIssueDetails.middleware.test.js
+++ b/test/unit/middleware/entityIssueDetails.middleware.test.js
@@ -232,7 +232,7 @@ describe('issueDetails.middleware.js', () => {
   })
 
   describe('show404ifNoIssues', () => {
-    it('raises 404 when on issues found', () => {
+    it('raises 404 when no issues found', () => {
       let next = vi.fn()
       show404ifNoIssues({ recordCount: 0 }, {}, next)
       expect(next).toHaveBeenCalledWith(new MiddlewareError('no issues found', 404))


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

We should show a 404 when entity issue details page fetches empty issues list. 

Without this change, accessing saved URLs can result in a 500 error. 

## Related Tickets & Documents

[Sentry error](https://planning-data-platform.sentry.io/issues/6528468194/?environment=production&project=4507033205800960&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=0)

## QA Instructions, Screenshots, Recordings


Accessing the URLs mentioned in sentry should no longer cause a 500. 

## Added/updated tests?

- [x] Yes

## QA sign off
- [ ] Code has been checked and approved
- [ ] Design has been checked and approved
- [ ] Product and business logic has been checked and proved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling to provide a clear 404 response when no issues are detected.
- **Tests**
	- Added test cases to verify the correct behaviour for both absent and present issue scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->