### PR TITLE
Fix broken links in submit form

### DIFF
--- a/src/views/submit/check-answers.html
+++ b/src/views/submit/check-answers.html
@@ -108,7 +108,7 @@
         actions: {
           items: [
           {
-            href: "/submit-endpoint/dataset-details",
+            href: "/submit/dataset-details",
             text: "Change",
             visuallyHiddenText: "webpage URL"
           }
@@ -125,7 +125,7 @@
         actions: {
           items: [
           {
-            href: "/submit-endpoint/dataset-details",
+            href: "/submit/dataset-details",
             text: "Change",
             visuallyHiddenText: "dataset"
           }


### PR DESCRIPTION
## Description

On the submit endpoint form, when checking answers, @Swati-Dash and I noticed that two of the hyperlinks to change your response were broken due to changes in the href details. This PR amends those to match the rest of the form and avoid broken links.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [X] No, and this is why: URL changes only
- [ ] I need help with writing tests