### PR TITLE
Disable Smartlook

### DIFF
--- a/config/production.yaml
+++ b/config/production.yaml
@@ -11,10 +11,10 @@ redis: {
     port: 6379
 }
 url: 'https://provide.planning.data.gov.uk/'
-smartlook: {
-  key: '6383ab27d6f6a02f043a518bea629cd232dc0131',
-  region: 'eu'
-}
+# smartlook: {
+#   key: '6383ab27d6f6a02f043a518bea629cd232dc0131',
+#   region: 'eu'
+# }
 googleAnalytics: {
   measurementId: 'G-F2H5SW06PZ'
 }


### PR DESCRIPTION
## Description

We're reducing the amount of work we do on Provide, but we're increasing the amount of work we do on the main platform website for data consumers. Instead of recording user sessions wastefully, this PR deactivates Smartlook on Provide, freeing up account limits for installing Smartlook on the main website.

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: Not required
- [ ] I need help with writing tests

## QA sign off
- [ ] Code has been checked and approved
- [ ] Design has been checked and approved
- [ ] Product and business logic has been checked and proved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled the "smartlook" service in the production configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->