### PR TITLE
parallel org info removal

### DIFF
--- a/src/middleware/lpa-overview.middleware.js
+++ b/src/middleware/lpa-overview.middleware.js
@@ -352,8 +352,8 @@ const fetchOutOfBoundsExpectations = expectationFetcher({
  * Organisation (LPA) overview page middleware chain.
  */
 export default [
+  fetchOrgInfo,
   parallel([
-    fetchOrgInfo,
     fetchEndpointSummary,
     fetchEntityIssueCountsPerformanceDb,
     fetchProvisions


### PR DESCRIPTION
Hotfix to stop fetchOrgInfo from failing in parallel loop and headers continuing to set after page not found is returned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimised the order of data loading operations to improve efficiency and data consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->