### PR TITLE
Improve page number validation for entityIssueDetails

### DIFF
--- a/src/middleware/entityIssueDetails.middleware.js
+++ b/src/middleware/entityIssueDetails.middleware.js
@@ -26,7 +26,17 @@ export const IssueDetailsQueryParams = v.object({
   dataset: v.string(),
   issue_type: v.string(),
   issue_field: v.string(),
-  pageNumber: v.optional(v.pipe(v.string(), v.transform(s => parseInt(s, 10)), v.number(), v.integer(), v.minValue(1)), '1'),
+  pageNumber: v.optional(
+    v.pipe(
+      v.string(),
+      v.regex(/^\d+$/),
+      v.transform(s => Number(s)),
+      v.number(),
+      v.integer(),
+      v.minValue(1)
+    ),
+    '1'
+  ),
   resourceId: v.optional(v.string())
 })
 

--- a/src/middleware/entityIssueDetails.middleware.js
+++ b/src/middleware/entityIssueDetails.middleware.js
@@ -26,7 +26,7 @@ export const IssueDetailsQueryParams = v.object({
   dataset: v.string(),
   issue_type: v.string(),
   issue_field: v.string(),
-  pageNumber: v.optional(v.pipe(v.string(), v.transform(s => parseInt(s, 10)), v.minValue(1)), '1'),
+  pageNumber: v.optional(v.pipe(v.string(), v.transform(s => parseInt(s, 10)), v.number(), v.integer(), v.minValue(1)), '1'),
   resourceId: v.optional(v.string())
 })
 

--- a/test/unit/middleware/entityIssueDetails.middleware.test.js
+++ b/test/unit/middleware/entityIssueDetails.middleware.test.js
@@ -1,5 +1,7 @@
 import { describe, it, vi, expect, beforeEach } from 'vitest'
-import { getIssueDetails, getIssueField, prepareEntity, setRecordCount, show404ifNoIssues } from '../../../src/middleware/entityIssueDetails.middleware.js'
+import * as v from 'valibot'
+import { isValiError } from 'valibot'
+import { IssueDetailsQueryParams, getIssueDetails, getIssueField, prepareEntity, setRecordCount, show404ifNoIssues } from '../../../src/middleware/entityIssueDetails.middleware.js'
 import { MiddlewareError } from '../../../src/utils/errors.js'
 
 vi.mock('../../../src/services/performanceDbApi.js')
@@ -253,6 +255,31 @@ describe('issueDetails.middleware.js', () => {
       next = vi.fn()
       show404ifNoIssues({ recordCount: 10 }, {}, next)
       expect(next).toHaveBeenCalledWith()
+    })
+  })
+
+  describe('IssueDetailsQueryParams', () => {
+    const validBaseParams = {
+      lpa: 'local-authority:LIV',
+      dataset: 'tree-preservation-zone',
+      issue_type: 'missing associated entity',
+      issue_field: 'tree-preservation-order'
+    }
+
+    it('transforms a valid numeric pageNumber string to a number', () => {
+      const result = v.parse(IssueDetailsQueryParams, { ...validBaseParams, pageNumber: '2' })
+      expect(result.pageNumber).toBe(2)
+    })
+
+    it('throws a ValiError when pageNumber is not numeric', () => {
+      let thrown
+      try {
+        v.parse(IssueDetailsQueryParams, { ...validBaseParams, pageNumber: 'TPO335.G19' })
+      } catch (error) {
+        thrown = error
+      }
+      expect(thrown).toBeDefined()
+      expect(isValiError(thrown)).toBe(true)
     })
   })
 })


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases, this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## Description

We are receiving URLs with alphanumeric reference numbers instead of page numbers. We do not know where these originate from at this stage but they are currently generating 500 errors, which is:
- not a good experience for users
- flooding Sentry with unhandled 500 errors

This change updates Valibot validation to assert that a number is passed. When a number is not passed, then we return a 400 Bad Request error, which is more appropriate and provides better feedback to both us for debugging, and to the user.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

<!--
For pull requests that relate to or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example, having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, GitHub will
automatically close the issue.
-->
- Closes #2626
https://github.com/digital-land/config/issues/2626

## QA Instructions, Screenshots, Recordings

<!--
Instructions on how to test your changes, a note
on the devices and browsers, this has been tested on, as well as any relevant
images for UI changes.
-->

Problem URL: https://provide.staging.planning.data.gov.uk/organisations/local-authority:LIV/tree-preservation-zone/missing%20associated%20entity/tree-preservation-order/entity/TPO335.G19

- Previously triggered unhandled 500 Error. 
  - Logged Error to Sentry
- Now returns handled 400 Error (Bad Request)
  - Does NOT log Error to Sentry

### Before

Browser:
<img width="1048" height="390" alt="Screenshot 2026-06-05 at 13 59 20" src="https://github.com/user-attachments/assets/c16308b7-732a-4e34-bcb1-1c1673025455" />

Sentry:
<img width="712" height="144" alt="Screenshot 2026-06-08 at 14 21 08" src="https://github.com/user-attachments/assets/af47fe23-2c65-4c66-b02e-8aefcd891507" />


### After

<img width="1053" height="417" alt="Screenshot 2026-06-05 at 13 59 45" src="https://github.com/user-attachments/assets/a30ccc11-9a58-485f-8685-edd9eca5a0f6" />

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [X] Yes
- [ ] No, and this is why: _Please replace this line with details on why tests have not been included_
- [ ] I need help with writing tests

## QA sign off
- [ ] Code has been checked and approved
- [ ] Design has been checked and approved
- [ ] Product and business logic has been checked and proved

## [optional] Are there any post-deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened page-number validation to accept only whole numeric values and enforce a minimum of 1, reducing invalid input acceptance.

* **Tests**
  * Added unit tests covering numeric-string parsing to numbers and rejecting non-numeric page-number inputs to ensure validation behaves as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->