### PR TITLE
Fix incorrect page number in check results URL and update related tes…

### DIFF
--- a/src/controllers/CheckAnswersController.js
+++ b/src/controllers/CheckAnswersController.js
@@ -79,7 +79,7 @@ class CheckAnswersController extends PageController {
     const datasetMeta = datasets.get(dataset) || {} // eslint-disable-line no-unused-vars
     const requestId = req.sessionModel.get('requestId')
     const checkTool = requestId
-      ? `${config.url}check/results/${requestId}/${config.jira.requestTypeId}`
+      ? `${config.url}check/results/${requestId}/1`
       : 'Check tool link unavailable'
 
     const isNonProd = ['local', 'development', 'staging'].includes(config.environment)

--- a/test/unit/checkAnswersController.test.js
+++ b/test/unit/checkAnswersController.test.js
@@ -86,7 +86,7 @@ describe('CheckAnswersController', () => {
 
   describe('createJiraServiceRequest', () => {
     it('should create a Jira service request using the existing requestId and attach a file', async () => {
-      config.jira.requestTypeId = '1'
+      config.jira.requestTypeId = '28'
       req.sessionModel.get.mockImplementation((key) => sessionData[key])
 
       const response = { data: { issueKey: 'TEST-123' } }
@@ -96,6 +96,10 @@ describe('CheckAnswersController', () => {
 
       const result = await controller.createJiraServiceRequest(req, res, next)
 
+      const [jiraRequest, jiraRequestTypeId] = createCustomerRequest.mock.calls[0]
+      expect(jiraRequest.description).toContain(`${config.url}check/results/existing-request-id/1`)
+      expect(jiraRequest.description).not.toContain(`${config.url}check/results/existing-request-id/${config.jira.requestTypeId}`)
+      expect(jiraRequestTypeId).toBe(config.jira.requestTypeId)
       expect(createCustomerRequest).toHaveBeenCalledWith(
         expect.objectContaining({
           description: expect.stringContaining(`${config.url}check/results/existing-request-id/1`)
@@ -148,7 +152,7 @@ describe('CheckAnswersController', () => {
     })
 
     it('should add geometry type for dataset tree', async () => {
-      config.jira.requestTypeId = '1'
+      config.jira.requestTypeId = '28'
       req.sessionModel.get.mockImplementation((key) => ({ ...sessionData, dataset: 'tree', geomType: 'polygon' })[key])
       const response = { data: { issueKey: 'TEST-123' } }
       createCustomerRequest.mockResolvedValue(response)
@@ -166,7 +170,7 @@ describe('CheckAnswersController', () => {
     })
 
     it('should include plugin in CSV attachment when plugin is retrieved', async () => {
-      config.jira.requestTypeId = '1'
+      config.jira.requestTypeId = '28'
       const mockRequestData = { getPlugin: vi.fn().mockReturnValue('wfs'), isComplete: vi.fn().mockReturnValue(true) }
       getRequestData.mockResolvedValue(mockRequestData)
       req.sessionModel.get.mockImplementation((key) => sessionData[key])
@@ -188,7 +192,7 @@ describe('CheckAnswersController', () => {
     })
 
     it('should not include geometry type when dataset is not tree', async () => {
-      config.jira.requestTypeId = '1'
+      config.jira.requestTypeId = '28'
       req.sessionModel.get.mockImplementation((key) => ({ ...sessionData, dataset: 'conservation-area', geomType: 'polygon' })[key])
       const response = { data: { issueKey: 'TEST-123' } }
       createCustomerRequest.mockResolvedValue(response)


### PR DESCRIPTION
## Description

Fixes the Check Tool link added to Jira service request descriptions so it always points to the first results page (`/check/results/:requestId/1`) instead of incorrectly using the Jira `requestTypeId` as the page number. Adds regression coverage to keep the results page number and Jira request type separate.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

- Closes #

## QA Instructions, Screenshots, Recordings

Run:

```bash
npx vitest run test/unit/checkAnswersController.test.js
test/unit/checkAnswersController.test.js
```

Verify that Jira request descriptions now include a Check Tool link like:

```text
/check/results/<request-id>/1
```

and not:

```text
/check/results/<request-id>/<jira-request-type-id>
```

### Before

Check Tool links in Jira descriptions could point to page `28` because `config.jira.requestTypeId` was used as the results page number.

### After

Check Tool links point to page `1`, while `config.jira.requestTypeId` is still passed separately to Jira when creating the service request.

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why:
- [ ] I need help with writing tests

## QA sign off

- [ ] Code has been checked and approved
- [ ] Design has been checked and approved
- [ ] Product and business logic has been checked and proved

## [optional] Are there any post-deployment tasks we need to perform?

None.

## [optional] Are there any dependencies on other PRs or Work?

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the format of Check Tool links in Jira service request descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->