### PR TITLE
fix: Exclude ended resources from duplicate endpoint check in query

### DIFF
--- a/src/utils/datasetteQueries/endpointAlreadyCollected.js
+++ b/src/utils/datasetteQueries/endpointAlreadyCollected.js
@@ -18,7 +18,6 @@ export async function endpointAlreadyCollectedForDataset ({ endpointUrl, dataset
       AND rd.dataset = '${sqlString(dataset)}'
       AND ro.organisation = '${sqlString(organisation)}'
       AND (e.end_date IS NULL OR e.end_date = '')
-      AND (r.end_date IS NULL OR r.end_date = '')
     LIMIT 1`
 
   const response = await datasette.runQuery(sql)

--- a/test/unit/utils/endpointAlreadyCollected.test.js
+++ b/test/unit/utils/endpointAlreadyCollected.test.js
@@ -86,6 +86,21 @@ describe('endpointAlreadyCollectedForDataset', () => {
     expect(datasette.runQuery.mock.calls[0][0]).not.toContain('REPLACE')
   })
 
+  it('does not exclude ended resources from the duplicate endpoint check', async () => {
+    datasette.runQuery.mockResolvedValue({ formattedData: [] })
+
+    await endpointAlreadyCollectedForDataset({
+      endpointUrl: 'https://example.com/data.csv',
+      dataset: 'brownfield-land',
+      organisation: 'local-authority:ABC'
+    })
+
+    const query = datasette.runQuery.mock.calls[0][0]
+
+    expect(query).toContain("(e.end_date IS NULL OR e.end_date = '')")
+    expect(query).not.toContain('r.end_date')
+  })
+
   it('does not query Datasette when endpoint URL or dataset is missing', async () => {
     await expect(endpointAlreadyCollectedForDataset({
       endpointUrl: '',


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Updates the duplicate endpoint check so ended resources no longer prevent an endpoint from being recognised as already collected for the same dataset and organisation.

The check still excludes ended endpoints.

## Related Tickets & Documents

- Ticket Link
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

Run the focused unit test:

```bash
npx vitest run test/unit/utils/endpointAlreadyCollected.test.js
```

Expected result: the test file passes, including coverage that the Datasette query no longer filters on `r.end_date` but still filters on `e.end_date`.

No screenshots or recordings are included because this is a backend query change with no UI impact.

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why:
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

None.

## [optional] Are there any dependencies on other PRs or Work?

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted duplicate-endpoint checking so ended resources are no longer incorrectly excluded.
  * Improved the query logic used to identify existing endpoint records.

* **Tests**
  * Added coverage to confirm the duplicate-check query no longer applies the removed resource-end-date filter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->