### PR TITLE
Add alert filter for false positive management

### DIFF
--- a/zap.yaml
+++ b/zap.yaml
@@ -25,6 +25,13 @@ jobs:
     parameters:
       maxDuration: 1
 
+  - type: alertFilter
+    parameters:
+      deleteGlobalAlerts: false
+    alertFilters:
+      - ruleId: 10062
+        newRisk: 'False Positive'
+
   - type: report
     parameters:
       template: traditional-md
@@ -39,7 +46,6 @@ jobs:
       - high
       - medium
       - low
-      - falsepositive
 
   - type: report
     parameters:
@@ -55,4 +61,3 @@ jobs:
       - high
       - medium
       - low
-      - falsepositive


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We have a high security scan alert for PII data in this repo. This is a false positive due to use of strings for dates etc - these are incorrectly flagged as potential credit card data. This is not data we collect.

This PR filters this alert out as a false positive so it no longer is included in the weekly reports.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [X] No, and this is why: Solely change to ZAP scan YAML
- [ ] I need help with writing tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Alerts matching rule 10062 are now classified as false positives.
  * Traditional Markdown and JSON reports no longer include false-positive confidence results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->