### PR TITLE
show endpoint count and how we process

### DIFF
--- a/src/middleware/dataview.middleware.js
+++ b/src/middleware/dataview.middleware.js
@@ -8,6 +8,7 @@ import {
   fetchLocalPlanningGroups,
   fetchProvisionsByOrgsAndDatasets,
   fetchOrgInfo,
+  fetchSources,
   noop,
   processAuthoritativeMiddlewares,
   processSpecificationMiddlewares,
@@ -92,7 +93,11 @@ const fetchOutOfBoundsExpectations = expectationFetcher({
 })
 
 export const prepareTemplateParams = (req, res, next) => {
-  const { orgInfo, dataset, tableParams, pagination, dataRange, tasks, authority, alternateSources, uniqueDatasetFields, provisions, expectationOutOfBounds } = req
+  const { orgInfo, dataset, tableParams, pagination, dataRange, tasks, authority, alternateSources, uniqueDatasetFields, provisions, expectationOutOfBounds, sources } = req
+
+  // Match the overview page: 'some' authority uses alternative/pre-populated
+  // sources, not the LPA's own endpoints, so it reports no endpoints.
+  const endpointCount = authority === 'some' ? 0 : (sources?.length ?? 0)
 
   const outOfBoundsCount = (expectationOutOfBounds?.length ?? 0) > 0 ? 1 : 0
   const taskCount = authority !== 'some' ? (tasks?.count ?? 0) + outOfBoundsCount : 1
@@ -112,6 +117,7 @@ export const prepareTemplateParams = (req, res, next) => {
     authority,
     dataset,
     taskCount,
+    endpointCount,
     tableParams,
     pagination,
     dataRange,
@@ -138,6 +144,7 @@ export default [
   fetchDatasetInfo,
 
   fetchResources,
+  fetchSources,
   fetchTasksFromPlatformApi,
   isFeatureEnabled('expectationOutOfBoundsTask') ? fetchOutOfBoundsExpectations : noop,
 

--- a/src/routes/schemas.js
+++ b/src/routes/schemas.js
@@ -213,6 +213,7 @@ export const OrgDataView = v.strictObject({
   organisation: OrgField,
   dataset: DatasetNameField,
   taskCount: v.integer(),
+  endpointCount: v.integer(),
   authority: v.string(),
   tableParams,
   pagination: PaginationParams,

--- a/src/views/organisations/dataset-overview.html
+++ b/src/views/organisations/dataset-overview.html
@@ -213,7 +213,7 @@
     {% if authority !== 'some' %}
     <section>
       <h2 class="govuk-heading-m">Active endpoints</h2>
-      <p class="govuk-body">You have {{ endpointCount }} endpoint{% if endpointCount != 1 %}s{% endif %} we are currently checking for data.</p>
+      <p class="govuk-body">You have {{ endpointCount }} endpoint{% if endpointCount != 1 %}s{% endif %} we are currently checking for data.{% if endpointCount > 1 %} The information within dataset details includes data from all {{ endpointCount }} endpoints.{% endif %}</p>
       {% for endpointSummaryCard in endpointSummaryCards %}
         {{ govukSummaryList(endpointSummaryCard) }}
       {% endfor %}

--- a/src/views/organisations/dataview.html
+++ b/src/views/organisations/dataview.html
@@ -60,6 +60,18 @@
 </div>
 
 <div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <section>
+      <h2 class="govuk-heading-m">About this data</h2>
+      <p class="govuk-body">We accept data in different formats and standardise it, so that we can combine it with data from other sources. This means the data we show might be in a different format to the data you provided. For example, we standardise all dates as YYYY-MM-DD.</p>
+      {% if endpointCount > 1 %}
+        <p class="govuk-body">The information within this data is from all {{ endpointCount }} of your endpoints.</p>
+      {% endif %}
+    </section>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     {{ table(tableParams) }}
   </div>

--- a/test/acceptance/request_check.test.js
+++ b/test/acceptance/request_check.test.js
@@ -284,7 +284,11 @@ test.describe('Request Check', () => {
       await resultsPage.expectPageHasTabs(false)
     })
 
-    test('request check of a @url that should cause a SSL error and display custom content', async ({ page }) => {
+    // TODO: skipped because serverErrorFile's SSL certificate has been renewed and now
+    // validates, so it no longer triggers the SSL error this test relies on. We need a
+    // reliable way to force an SSL failure (e.g. a badssl.com endpoint or a locally-served
+    // bad cert) before re-enabling. See https://github.com/digital-land/submit/pull/1231
+    test.skip('request check of a @url that should cause a SSL error and display custom content', async ({ page }) => {
       log('request check of a @url that should cause a SSL error and display custom content', true)
 
       const startPage = await navigateToCheck(page)

--- a/test/acceptance/request_check.test.js
+++ b/test/acceptance/request_check.test.js
@@ -21,7 +21,6 @@ const navigateToCheck = async (page) => {
 
 const okFile = 'https://raw.githubusercontent.com/digital-land/PublishExamples/refs/heads/main/Article4Direction/Files/Article4DirectionArea/article4directionareas-ok.csv'
 const errorFile = 'https://raw.githubusercontent.com/digital-land/PublishExamples/refs/heads/main/Article4Direction/Files/Article4DirectionArea/article4directionareas-errors.csv'
-// TODO: this file should cause a SSL Certificate error when served to the async. It currently does but is temporary (A link that causes a Server Timeout Error or SSL Error is required)
 const serverErrorFile = 'http://expired.badssl.com'
 const htmlFile = 'https://en.wikipedia.org/wiki/John_Doe'
 

--- a/test/acceptance/request_check.test.js
+++ b/test/acceptance/request_check.test.js
@@ -22,7 +22,7 @@ const navigateToCheck = async (page) => {
 const okFile = 'https://raw.githubusercontent.com/digital-land/PublishExamples/refs/heads/main/Article4Direction/Files/Article4DirectionArea/article4directionareas-ok.csv'
 const errorFile = 'https://raw.githubusercontent.com/digital-land/PublishExamples/refs/heads/main/Article4Direction/Files/Article4DirectionArea/article4directionareas-errors.csv'
 // TODO: this file should cause a SSL Certificate error when served to the async. It currently does but is temporary (A link that causes a Server Timeout Error or SSL Error is required)
-const serverErrorFile = 'https://www.tendringdc.gov.uk/sites/default/files/documents/planning/CAD%20csv.csv'
+const serverErrorFile = 'http://expired.badssl.com'
 const htmlFile = 'https://en.wikipedia.org/wiki/John_Doe'
 
 let lastTimestamp = 0
@@ -284,11 +284,7 @@ test.describe('Request Check', () => {
       await resultsPage.expectPageHasTabs(false)
     })
 
-    // TODO: skipped because serverErrorFile's SSL certificate has been renewed and now
-    // validates, so it no longer triggers the SSL error this test relies on. We need a
-    // reliable way to force an SSL failure (e.g. a badssl.com endpoint or a locally-served
-    // bad cert) before re-enabling. See https://github.com/digital-land/submit/pull/1231
-    test.skip('request check of a @url that should cause a SSL error and display custom content', async ({ page }) => {
+    test('request check of a @url that should cause a SSL error and display custom content', async ({ page }) => {
       log('request check of a @url that should cause a SSL error and display custom content', true)
 
       const startPage = await navigateToCheck(page)

--- a/test/unit/middleware/dataview.middleware.test.js
+++ b/test/unit/middleware/dataview.middleware.test.js
@@ -206,6 +206,7 @@ describe('dataview.middleware.test.js', () => {
         dataset: { name: 'Mock Dataset', dataset: 'mock-dataset' },
         authority: 'mock-authority',
         taskCount: 0,
+        endpointCount: 0,
         tableParams: { columns: ['foo'], fields: ['foo'] },
         pagination: {},
         dataRange: {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds content to better explain the data shown on the dataset details and dataset table tabs.

- **Dataset details tab** – when an LPA has provided more than one endpoint, the "Active endpoints" section now also explains that the details include data from all of their endpoints.
- **Dataset table tab** – adds an "About this data" section explaining that we standardise the data. The endpoint sentence only shows when the LPA has provided more than one endpoint.

The endpoint count is derived the same way on both tabs (from the LPA's own sources; `some`/alternative-source datasets report no endpoints).

## Related Tickets & Documents

- Ticket 2775

## QA Instructions, Screenshots, Recordings

Change 1 on the dataset overview page:

<img width="987" height="595" alt="image" src="https://github.com/user-attachments/assets/78a3743c-6c9b-4174-a259-d98446049f63" />

Change 2 on the data view page:

<img width="987" height="595" alt="image" src="https://github.com/user-attachments/assets/1e405eab-701d-4462-af83-780fa60a1180" />

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
- [ ] I need help with writing tests
