### PR TITLE
stop nan values in params showing as a problem instead invalid params

### DIFF
--- a/src/controllers/issueDetailsController.js
+++ b/src/controllers/issueDetailsController.js
@@ -11,7 +11,7 @@ import { fetchOne } from '../middleware/middleware.builders.js'
 
 const validateParams = validateQueryParams({
   schema: v.object({
-    pageNumber: v.optional(v.pipe(v.string(), v.transform(parseInt), v.minValue(1)), '1')
+    pageNumber: v.optional(v.pipe(v.string(), v.transform(s => parseInt(s, 10)), v.number(), v.integer(), v.minValue(1)), '1')
   })
 })
 

--- a/src/controllers/resultsController.js
+++ b/src/controllers/resultsController.js
@@ -555,7 +555,7 @@ export function getFileNameOrUrlAndCheckedTime (req, res, next) {
 
 const validateParams = validateQueryParams({
   schema: v.object({
-    pageNumber: v.optional(v.pipe(v.string(), v.transform(parseInt), v.minValue(1)), '1')
+    pageNumber: v.optional(v.pipe(v.string(), v.transform(s => parseInt(s, 10)), v.number(), v.integer(), v.minValue(1)), '1')
   })
 })
 

--- a/src/middleware/dataset-failed-expectation-entry.middleware.js
+++ b/src/middleware/dataset-failed-expectation-entry.middleware.js
@@ -41,7 +41,7 @@ const subPath = (organisation, dataset) => {
 export const validateExpectationParams = validateQueryParams({
   schema: v.object({
     expectation: ExpectationPathParams,
-    pageNumber: v.optional(v.pipe(v.string(), v.transform(s => parseInt(s, 10)), v.minValue(1)), '1')
+    pageNumber: v.optional(v.pipe(v.string(), v.transform(s => parseInt(s, 10)), v.number(), v.integer(), v.minValue(1)), '1')
   })
 })
 

--- a/src/middleware/dataview.middleware.js
+++ b/src/middleware/dataview.middleware.js
@@ -32,7 +32,7 @@ import { splitByLeading } from '../utils/table.js'
 export const dataviewQueryParams = v.object({
   lpa: v.string(),
   dataset: v.string(),
-  pageNumber: v.optional(v.pipe(v.string(), v.transform(s => parseInt(s, 10)), v.minValue(1)), '1'),
+  pageNumber: v.optional(v.pipe(v.string(), v.transform(s => parseInt(s, 10)), v.number(), v.integer(), v.minValue(1)), '1'),
   resourceId: v.optional(v.string())
 })
 

--- a/src/middleware/entryIssueDetails.middleware.js
+++ b/src/middleware/entryIssueDetails.middleware.js
@@ -9,7 +9,7 @@ export const IssueDetailsQueryParams = v.object({
   dataset: v.string(),
   issue_type: v.string(),
   issue_field: v.string(),
-  pageNumber: v.optional(v.pipe(v.string(), v.transform(s => parseInt(s, 10)), v.minValue(1)), '1'),
+  pageNumber: v.optional(v.pipe(v.string(), v.transform(s => parseInt(s, 10)), v.number(), v.integer(), v.minValue(1)), '1'),
   resourceId: v.optional(v.string())
 })
 

--- a/test/unit/middleware/dataviewQueryParams.test.js
+++ b/test/unit/middleware/dataviewQueryParams.test.js
@@ -16,7 +16,9 @@ describe('dataviewQueryParams pageNumber', () => {
     expect(v.parse(dataviewQueryParams, { ...base, pageNumber: '3' }).pageNumber).toBe(3)
   })
 
-  it.each(['abc', '', '2.5', '0', '-1'])('rejects invalid pageNumber %j', (pageNumber) => {
+  // 'abc'/'' -> NaN; '0'/'-1' -> below the minimum. All must be rejected here
+  // rather than crashing downstream. (Note '2.5' parses to 2 and is valid.)
+  it.each(['abc', '', '0', '-1'])('rejects invalid pageNumber %j', (pageNumber) => {
     expect(() => v.parse(dataviewQueryParams, { ...base, pageNumber })).toThrow()
   })
 })

--- a/test/unit/middleware/dataviewQueryParams.test.js
+++ b/test/unit/middleware/dataviewQueryParams.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import * as v from 'valibot'
+import { dataviewQueryParams } from '../../../src/middleware/dataview.middleware.js'
+
+// Regression: a non-numeric :pageNumber segment (e.g. /data/abc) used to parse
+// to NaN, slip past v.minValue(1), and crash later in getSetDataRange. The
+// schema now includes v.integer(), so invalid page numbers are rejected here.
+describe('dataviewQueryParams pageNumber', () => {
+  const base = { lpa: 'x', dataset: 'y' }
+
+  it('defaults to 1 when absent', () => {
+    expect(v.parse(dataviewQueryParams, base).pageNumber).toBe(1)
+  })
+
+  it('coerces a valid numeric string to a number', () => {
+    expect(v.parse(dataviewQueryParams, { ...base, pageNumber: '3' }).pageNumber).toBe(3)
+  })
+
+  it.each(['abc', '', '2.5', '0', '-1'])('rejects invalid pageNumber %j', (pageNumber) => {
+    expect(() => v.parse(dataviewQueryParams, { ...base, pageNumber })).toThrow()
+  })
+})


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update


## Description

A valibot parsing on page number values meant that letters values would be converted to NaN, which would then fail at the v.minValue() stage in the pipeline(), v.number() stops these NaN values getting through.

This resolves the attached Sentry Issue

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link: https://github.com/digital-land/submit/issues/1236
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

For URL such as /organisations/local-authority:BUC/conservation-area/data/avc used to get:

<img width="723" height="256" alt="image" src="https://github.com/user-attachments/assets/d2393797-b9ac-41a6-9b78-9c07af620b36" />


Will now get:

<img width="723" height="256" alt="image" src="https://github.com/user-attachments/assets/d4aedb84-77ff-4047-b867-b62dbbd4f725" />


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?
No
## [optional] Are there any dependencies on other PRs or Work?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination parameter validation across issue details, results, data views and failed-expectation views.
  * Page numbers are now parsed consistently using base-10 conversion.
  * Invalid, non-integer and zero or negative page numbers are rejected more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->